### PR TITLE
wrong translation in Russian menu

### DIFF
--- a/levels/train401/po/ru.po
+++ b/levels/train401/po/ru.po
@@ -26,7 +26,7 @@ msgstr "R"
 #: train401/scene.txt:1 train401/scene.txt:3
 #, no-wrap
 msgid "train401:Dragster"
-msgstr "train401:Миноискатель\n"
+msgstr "train401:Миноискатель"
 
 #. type: Resume-text
 #: train401/scene.txt:2


### PR DESCRIPTION
Error Occures in "Exercises"->"Motors"->"Dragster"
Here is screenshot:

![text](https://f.cloud.github.com/assets/2958584/1813570/e9b4ab20-6ec4-11e3-8637-6fd1dc14cc3b.png)
