### PR TITLE
Sort input file list

### DIFF
--- a/i18n-tools/scripts/common.py
+++ b/i18n-tools/scripts/common.py
@@ -150,7 +150,7 @@ class LanguageFile:
 def find_translation_file_names(po_dir):
     pot_file_name = os.path.join(po_dir, 'translations.pot') # default
     po_file_names = []
-    for file_name in os.listdir(po_dir):
+    for file_name in sorted(os.listdir(po_dir)):
         if file_name.endswith('.pot'):
             pot_file_name = os.path.join(po_dir, file_name)
         elif file_name.endswith('.po'):


### PR DESCRIPTION
Sort input file list
so that chaptertitle.txt builds in a reproducible way
in spite of indeterministic filesystem readdir order.

See https://reproducible-builds.org/ for why this is good.

This PR was done while working on reproducible builds for openSUSE.