### PR TITLE
Fixing typos in help files

### DIFF
--- a/levels/exercises/chapter002/level003/help/help.E.txt
+++ b/levels/exercises/chapter002/level003/help/help.E.txt
@@ -34,7 +34,7 @@ You can give the instruction \c;\l;radar\u cbot\radar();\n; more parameters (num
 \n;
 Notice that two equal signs "==" are needed to perform a comparison of equality.
 
-Just insert these lines before the instruction \c;fire(0);\n;, and the bot will wait before shooting until the ant is closer than 40 meters. Like this a regular power cell is enough to kill all ants. 
+Just insert these lines before the instruction \c;fire(1);\n;, and the bot will wait before shooting until the ant is closer than 40 meters. Like this a regular power cell is enough to kill all ants. 
 
 \t;See also
 \l;Programming\u cbot;, \l;types\u cbot\type; and \l;categories\u cbot\category;.

--- a/levels/exercises/chapter003/level009/help/help.E.txt
+++ b/levels/exercises/chapter003/level009/help/help.E.txt
@@ -11,7 +11,7 @@ An information exchange post stores "name/value" couples. To control the "slave"
 
     name="order", valuer=order number
 
-The slace robot understands following orders:
+The slave robot understands following orders:
 \c;
     1 -> grab();     // take an object
     2 -> drop();     // drop an object


### PR DESCRIPTION
Fixing typos in help files of the exercises