### PR TITLE
Switch required Python version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.16)
 option(TRANSLATIONS "Enable translations of help and level files" ON)
 
 if(TRANSLATIONS)
-    find_package(PythonInterp 2.7 REQUIRED)
+    find_package(PythonInterp 3.0 REQUIRED)
 else()
     message(STATUS "Translations disabled; only English files will be installed")
 endif()


### PR DESCRIPTION
Since Python 2 is unsupported, and scripts are running fine with Python 3, we can change required Python version to solve issues with inaccessible Python 2 in repositories.