### PR TITLE
Fix translation error in abstime()

### DIFF
--- a/help/cbot/po/ru.po
+++ b/help/cbot/po/ru.po
@@ -32,7 +32,7 @@ msgstr "Синтаксис:"
 #: ../E/abstime.txt:3
 #, no-wrap
 msgid "<c/>abstime ( );<n/>"
-msgstr "<c/>thump ( );<n/>"
+msgstr "<c/>abstime ( );<n/>"
 
 #. type: Plain text
 #: ../E/abstime.txt:5


### PR DESCRIPTION
Due to a mistake the Russian documentation for `abstime()` was referring to it as `thump()`:

![image](https://github.com/colobot/colobot-data/assets/52621858/2b613061-69e1-4585-a28c-b8fbf684fd20)

Let's fix this.