### PR TITLE
Modernize EndingFile

### DIFF
--- a/levels/battles/level_common.txt
+++ b/levels/battles/level_common.txt
@@ -1,6 +1,5 @@
 HelpFile name="cbot.txt"
 Instructions name="%lvl%/help/help.%lng%.txt"
-EndingFile win=-1 lost=-1
 
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey
 FogColor air=0.816;0.784;0.875;0.000 water=0.369;0.600;0.706;0.000 // magenta

--- a/levels/challenges/chapter001/level001/scene.txt
+++ b/levels/challenges/chapter001/level001/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Move the bot along a given path."
 ScriptName.E text="Move"
 Instructions name="%lvl%/help/help.%lng%.txt" immediat=1
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/challenges/chapter001/level002/scene.txt
+++ b/levels/challenges/chapter001/level002/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Use a loop in order to destroy four targets."
 ScriptName.E text="Go"
 Instructions name="%lvl%/help/help.%lng%.txt" immediat=1
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/challenges/chapter001/level003/scene.txt
+++ b/levels/challenges/chapter001/level003/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Collect lots of valuable information from information exchange po
 ScriptName.E text="Info"
 Instructions name="%lvl%/help/help.%lng%.txt" immediat=1
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/challenges/chapter001/level004/scene.txt
+++ b/levels/challenges/chapter001/level004/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Teach your bot how to find its way out of the labyrinth."
 ScriptName.E text="Labyrinth"
 Instructions name="%lvl%/help/help.%lng%.txt" immediat=1
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/challenges/chapter002/level001/scene.txt
+++ b/levels/challenges/chapter002/level001/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Use the radar to put some order into a big mess left behind by a 
 ScriptName.E text="Radar"
 Instructions name="%lvl%/help/help.%lng%.txt" immediat=1
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/challenges/chapter002/level002/scene.txt
+++ b/levels/challenges/chapter002/level002/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Follow a bot, as if you were its shadow."
 ScriptName.E text="Follow"
 Instructions name="%lvl%/help/help.%lng%.txt" immediat=1
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/challenges/chapter002/level003/scene.txt
+++ b/levels/challenges/chapter002/level003/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Defend yourself agains all alien attacks."
 ScriptName.E text="Defense"
 Instructions name="%lvl%/help/help.%lng%.txt" immediat=1
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/challenges/chapter002/level004/scene.txt
+++ b/levels/challenges/chapter002/level004/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Use your radar to look for various items, but watch out for the m
 ScriptName.E text="Traps"
 Instructions name="%lvl%/help/help.%lng%.txt" immediat=1
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/challenges/chapter002/level005/scene.txt
+++ b/levels/challenges/chapter002/level005/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Try to figure out how to survive in a hostile environment."
 ScriptName.E text="Traps"
 Instructions name="%lvl%/help/help.%lng%.txt" immediat=1
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/challenges/chapter003/level001/scene.txt
+++ b/levels/challenges/chapter003/level001/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Retrieve some titanium ore in order to convert it to titanium cub
 ScriptName.E text="Mover"
 Instructions name="%lvl%/help/help.%lng%.txt" immediat=1
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/challenges/chapter003/level002/scene.txt
+++ b/levels/challenges/chapter003/level002/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Try to figure out how to move the titanium cube across obstacles.
 ScriptName.E text="Mover"
 Instructions name="%lvl%/help/help.%lng%.txt" immediat=1
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/challenges/chapter004/level001/scene.txt
+++ b/levels/challenges/chapter004/level001/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Create a function to move a bot."
 ScriptName.E text="Move"
 Instructions name="%lvl%/help/help.%lng%.txt" immediat=1
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/challenges/chapter004/level002/scene.txt
+++ b/levels/challenges/chapter004/level002/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Create a procedure in order to teach your bot to perform a spiral
 ScriptName.E text="Move"
 Instructions name="%lvl%/help/help.%lng%.txt" immediat=1
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter001/level001/scene.txt
+++ b/levels/exercises/chapter001/level001/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Kill three spiders with a small program."
 ScriptName.E text="Spider1"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=2 lost=0
+EndingFile win="other/win002.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter001/level002/scene.txt
+++ b/levels/exercises/chapter001/level002/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Instruct a bot to change the power cell of a nearby winged shoote
 ScriptName.E text="Spider2"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=2 lost=0
+EndingFile win="other/win002.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter001/level003/scene.txt
+++ b/levels/exercises/chapter001/level003/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Take a chunk of titanium ore and bring it to the converter."
 ScriptName.E text="Titanium1"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=2 lost=0
+EndingFile win="other/win002.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter001/level004/scene.txt
+++ b/levels/exercises/chapter001/level004/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Use the bot's radar to look for the titanium ore and bring it to 
 ScriptName.E text="Titanium2"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=2 lost=0
+EndingFile win="other/win002.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter001/level005/scene.txt
+++ b/levels/exercises/chapter001/level005/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Power all the winged shooters."
 ScriptName.E text="Spider2"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=2 lost=0
+EndingFile win="other/win002.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter001/level006/scene.txt
+++ b/levels/exercises/chapter001/level006/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Use the radar to find and kill all spiders."
 ScriptName.E text="Spider2"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=2 lost=0
+EndingFile win="other/win002.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter001/level007/scene.txt
+++ b/levels/exercises/chapter001/level007/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Learn to move the bot so that no spider can escape."
 ScriptName.E text="Spider3"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=2 lost=0
+EndingFile win="other/win002.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter002/level001/scene.txt
+++ b/levels/exercises/chapter002/level001/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Set the power of the different motors in order to achieve a barra
 ScriptName.E text="Move"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=3 lost=0
+EndingFile win="other/win003.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.533;0.533;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter002/level002/scene.txt
+++ b/levels/exercises/chapter002/level002/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Make a flying defense tower out of a winged shooter."
 ScriptName.E text="Move"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=3 lost=0
+EndingFile win="other/win003.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.533;0.533;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter002/level003/scene.txt
+++ b/levels/exercises/chapter002/level003/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Program a flying tower that wastes less energy."
 ScriptName.E text="Move"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=3 lost=0
+EndingFile win="other/win003.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.533;0.533;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter002/level004/scene.txt
+++ b/levels/exercises/chapter002/level004/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Instruct a winged shooter to clean the whole region."
 ScriptName.E text="Move"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=4 lost=0
+EndingFile win="other/win004.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.596;0.596;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter002/level005/scene.txt
+++ b/levels/exercises/chapter002/level005/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Adapt the program to a mountainous terrain."
 ScriptName.E text="Move"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=4 lost=0
+EndingFile win="other/win004.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.596;0.596;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter002/level006/scene.txt
+++ b/levels/exercises/chapter002/level006/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Shoot down the flying wasps."
 ScriptName.E text="Wasp1"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=4 lost=0
+EndingFile win="other/win004.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.596;0.596;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter002/level007/scene.txt
+++ b/levels/exercises/chapter002/level007/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Get better at shooting down the wasps."
 ScriptName.E text="Wasp2"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=4 lost=0
+EndingFile win="other/win004.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.596;0.596;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter003/level001/scene.txt
+++ b/levels/exercises/chapter003/level001/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Move the bot along a given path."
 ScriptName.E text="Move"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter003/level002/scene.txt
+++ b/levels/exercises/chapter003/level002/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Use variables in order to store the parameters of the path."
 ScriptName.E text="Move"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter003/level003/scene.txt
+++ b/levels/exercises/chapter003/level003/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Use a loop in order to destroy six targets."
 ScriptName.E text="Go"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter003/level004/scene.txt
+++ b/levels/exercises/chapter003/level004/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Collect valuable information from information exchange posts."
 ScriptName.E text="Info"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter003/level005/scene.txt
+++ b/levels/exercises/chapter003/level005/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Collect more valuable information from information exchange posts
 ScriptName.E text="Info"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter003/level006/scene.txt
+++ b/levels/exercises/chapter003/level006/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Teach your bot how to find its way out of the labyrinth."
 ScriptName.E text="Labyrinth"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter003/level007/scene.txt
+++ b/levels/exercises/chapter003/level007/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Teach your bot to do the same job in a more autonomous way."
 ScriptName.E text="Labyrinth"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter003/level008/scene.txt
+++ b/levels/exercises/chapter003/level008/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Instruct your bot to search a zone for subsoil resources."
 ScriptName.E text="Digger"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter003/level009/scene.txt
+++ b/levels/exercises/chapter003/level009/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Remote control a robot using an information exchange post, so it 
 ScriptName.E text="remote"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter004/level001/scene.txt
+++ b/levels/exercises/chapter004/level001/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Program a progressive deceleration in order to avoid the mines ri
 ScriptName.E text="Dragster"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter004/level002/scene.txt
+++ b/levels/exercises/chapter004/level002/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Use the radar to find lots of stupid blue crosses."
 ScriptName.E text="Find"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter004/level003/scene.txt
+++ b/levels/exercises/chapter004/level003/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Use the radar to put some order into a big mess left behind by a 
 ScriptName.E text="Move"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter004/level004/scene.txt
+++ b/levels/exercises/chapter004/level004/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Be patient enough not to waste your ammunitions."
 ScriptName.E text="Patient"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter004/level005/scene.txt
+++ b/levels/exercises/chapter004/level005/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Follow a bot, as if you were its shadow."
 ScriptName.E text="Follow"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter005/level001/scene.txt
+++ b/levels/exercises/chapter005/level001/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Retrieve a titanium cube."
 ScriptName.E text="Mover"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter005/level002/scene.txt
+++ b/levels/exercises/chapter005/level002/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Retrieve several titanium cubes."
 ScriptName.E text="Mover"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter005/level003/scene.txt
+++ b/levels/exercises/chapter005/level003/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Convert some titanium ore to titanium cubes."
 ScriptName.E text="Mover"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter005/level004/scene.txt
+++ b/levels/exercises/chapter005/level004/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Move a titanium cube across obstacles."
 ScriptName.E text="Mover"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter006/level001/scene.txt
+++ b/levels/exercises/chapter006/level001/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Create a function in order to make your program shorter."
 ScriptName.E text="Move"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter006/level002/scene.txt
+++ b/levels/exercises/chapter006/level002/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Create a procedure in order to teach your bot to perform a spiral
 ScriptName.E text="Move"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter006/level003/scene.txt
+++ b/levels/exercises/chapter006/level003/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Remote control a robot using an information exchange post, so it 
 ScriptName.E text="remote"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter007/level001/scene.txt
+++ b/levels/exercises/chapter007/level001/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Remote control a bot without using an information exchange post b
 ScriptName.E text="Remote3"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter007/level002/scene.txt
+++ b/levels/exercises/chapter007/level002/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Remote control a bot without using an information exchange post b
 ScriptName.E text="Remote4"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/exercises/chapter007/level003/scene.txt
+++ b/levels/exercises/chapter007/level003/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Remote control a bot without using an information exchange post b
 ScriptName.E text="Remote5"
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=1 lost=0
+EndingFile win="other/win001.txt" lost="other/lost000.txt"
 
  
 AmbientColor air=0.400;0.400;0.400;0.400 water=0.078;0.078;0.078;0.078 // grey

--- a/levels/free/chapter001/level001/scene.txt
+++ b/levels/free/chapter001/level001/scene.txt
@@ -2,7 +2,6 @@ Title.E text="Free game"
 Resume.E text="Do whatever you want, build a base camp and some bots, without any precise objective."
 Instructions name="freehelp.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=-1
 
 Audio filename="music002.ogg"
 

--- a/levels/free/chapter002/level001/scene.txt
+++ b/levels/free/chapter002/level001/scene.txt
@@ -2,7 +2,6 @@ Title.E text="Free game"
 Resume.E text="Do whatever you want, build a base camp and some bots, without any precise objective."
 Instructions name="freehelp.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=-1
 
 #Include file="levels/missions/chapter002/planet.txt"
 TerrainRelief image="relief03.png" factor=1.0

--- a/levels/free/chapter003/level001/scene.txt
+++ b/levels/free/chapter003/level001/scene.txt
@@ -2,7 +2,6 @@ Title.E text="Free game"
 Resume.E text="Do whatever you want, build a base camp and some bots, without any precise objective."
 Instructions name="freehelp.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=-1
 
 Audio filename="music003.ogg"
 

--- a/levels/free/chapter004/level001/scene.txt
+++ b/levels/free/chapter004/level001/scene.txt
@@ -2,7 +2,6 @@ Title.E text="Free game"
 Resume.E text="Do whatever you want, build a base camp and some bots, without any precise objective."
 Instructions name="freehelp.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=-1
 
 Audio filename="music004.ogg"
 

--- a/levels/free/chapter005/level001/scene.txt
+++ b/levels/free/chapter005/level001/scene.txt
@@ -2,7 +2,6 @@ Title.E text="Free game"
 Resume.E text="Do whatever you want, build a base camp and some bots, without any precise objective."
 Instructions name="freehelp.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=-1
 
 Audio filename="music005.ogg"
 

--- a/levels/free/chapter006/level001/scene.txt
+++ b/levels/free/chapter006/level001/scene.txt
@@ -2,7 +2,6 @@ Title.E text="Free game"
 Resume.E text="Do whatever you want, build a base camp and some bots, without any precise objective."
 Instructions name="freehelp.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=-1
 
 Audio filename="music006.ogg"
 

--- a/levels/free/chapter007/level001/scene.txt
+++ b/levels/free/chapter007/level001/scene.txt
@@ -2,7 +2,6 @@ Title.E text="Free game"
 Resume.E text="Do whatever you want, build a base camp and some bots, without any precise objective."
 Instructions name="freehelp.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=-1
 
 Audio filename="music007.ogg"
 

--- a/levels/free/chapter008/level001/scene.txt
+++ b/levels/free/chapter008/level001/scene.txt
@@ -2,7 +2,6 @@ Title.E text="Free game"
 Resume.E text="Do whatever you want, build a base camp and some bots, without any precise objective."
 Instructions name="freehelp.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=-1
 
 Audio filename="music008.ogg"
 

--- a/levels/free/chapter009/level001/scene.txt
+++ b/levels/free/chapter009/level001/scene.txt
@@ -2,7 +2,6 @@ Title.E text="Free game"
 Resume.E text="Do whatever you want, build a base camp and some bots, without any precise objective."
 Instructions name="freehelp.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=-1
 
 Audio filename="music009.ogg"
 

--- a/levels/missions/chapter001/level001/scene.txt
+++ b/levels/missions/chapter001/level001/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Prepare yourself to embark on mankind's most thrilling adventure 
 Instructions name="%lvl%/help/help.%lng%.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=101 lost=0
+EndingFile win="other/win101.txt" lost="other/lost000.txt"
 MessageDelay factor=5
 
 Audio filename="music002.ogg"

--- a/levels/missions/chapter001/level002/scene.txt
+++ b/levels/missions/chapter001/level002/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Learn how to construct buildings."
 Instructions name="%lvl%/help/help.%lng%.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=102 lost=0
+EndingFile win="other/win102.txt" lost="other/lost000.txt"
 MessageDelay factor=3
 
 Audio filename="music002.ogg"

--- a/levels/missions/chapter001/level003/scene.txt
+++ b/levels/missions/chapter001/level003/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Equip your spaceship and get ready for takeoff."
 Instructions name="%lvl%/help/help.%lng%.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 MessageDelay factor=2
 
 Audio filename="music002.ogg"

--- a/levels/missions/chapter002/level001/scene.txt
+++ b/levels/missions/chapter002/level001/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/1_SwitchCell1.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=201 lost=0
+EndingFile win="other/win201.txt" lost="other/lost000.txt"
 
 // Planets for SpaceShip transition animation
 Planet mode=1 pos=1.0;0.2 dim=0.50 speed=0.0 dir=0.3 image="planets/planet-earth.png" uv1=0.0;0.0 uv2=1.0;1.0

--- a/levels/missions/chapter002/level002/scene.txt
+++ b/levels/missions/chapter002/level002/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/1_SwitchCell1_link.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=202 lost=0
+EndingFile win="other/win202.txt" lost="other/lost000.txt"
 
 #Include file="%chap%/planet.txt"
 TerrainRelief image="relief03.png" factor=1.0

--- a/levels/missions/chapter002/level003/scene.txt
+++ b/levels/missions/chapter002/level003/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/1_SwitchCell1_link.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=203 lost=0
+EndingFile win="other/win203.txt" lost="other/lost000.txt"
 
 #Include file="%chap%/planet.txt"
 TerrainRelief image="relief03.png" factor=1.0

--- a/levels/missions/chapter002/level004/scene.txt
+++ b/levels/missions/chapter002/level004/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/2_Recharge1.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 #Include file="%chap%/planet.txt"
 TerrainRelief image="relief13.png" factor=1.0

--- a/levels/missions/chapter003/level001/scene.txt
+++ b/levels/missions/chapter003/level001/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/2_Recharge1_link.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music003.ogg"
 

--- a/levels/missions/chapter003/level002/scene.txt
+++ b/levels/missions/chapter003/level002/scene.txt
@@ -3,7 +3,7 @@ Resume.E text="Find your spaceship in the Tropica maze."
 Instructions name="%lvl%/help/help.%lng%.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music003.ogg"
 

--- a/levels/missions/chapter003/level003/scene.txt
+++ b/levels/missions/chapter003/level003/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/3_Recharge2.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 AudioChange pos=0.00;0.00 dist=25000.00 tool=Shooter powermin=0.8 filename="Constructive.ogg" repeat=0
 

--- a/levels/missions/chapter003/level004/scene.txt
+++ b/levels/missions/chapter003/level004/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/3_Recharge2_link.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music003.ogg"
 

--- a/levels/missions/chapter003/level005/scene.txt
+++ b/levels/missions/chapter003/level005/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/3_Recharge2.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music003.ogg"
 

--- a/levels/missions/chapter004/level001/scene.txt
+++ b/levels/missions/chapter004/level001/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/4_CollectTitanium1.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music004.ogg"
 

--- a/levels/missions/chapter004/level002/scene.txt
+++ b/levels/missions/chapter004/level002/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/5_CollectTitanium2.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music004.ogg"
 

--- a/levels/missions/chapter004/level003/scene.txt
+++ b/levels/missions/chapter004/level003/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/5_CollectTitanium2_link.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music004.ogg"
 

--- a/levels/missions/chapter004/level004/scene.txt
+++ b/levels/missions/chapter004/level004/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/5_CollectTitanium2_link.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music004.ogg"
 

--- a/levels/missions/chapter005/level001/scene.txt
+++ b/levels/missions/chapter005/level001/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/5_CollectTitanium2_link.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music005.ogg"
 

--- a/levels/missions/chapter005/level002/scene.txt
+++ b/levels/missions/chapter005/level002/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/6_KillAnt1.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="Quite.ogg"
 

--- a/levels/missions/chapter005/level003/scene.txt
+++ b/levels/missions/chapter005/level003/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/6_KillAnt1_link.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music005.ogg"
 

--- a/levels/missions/chapter006/level001/scene.txt
+++ b/levels/missions/chapter006/level001/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/7_CollectTitanium3.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music006.ogg"
 

--- a/levels/missions/chapter006/level002/scene.txt
+++ b/levels/missions/chapter006/level002/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/8_ServiceTower1.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music006.ogg"
 

--- a/levels/missions/chapter006/level003/scene.txt
+++ b/levels/missions/chapter006/level003/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/8_ServiceTower1_link.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music006.ogg"
 

--- a/levels/missions/chapter006/level004/scene.txt
+++ b/levels/missions/chapter006/level004/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/8_ServiceTower1_link.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=604 lost=0
+EndingFile win="other/win604.txt" lost="other/lost000.txt"
 
 Audio filename="music006.ogg"
 

--- a/levels/missions/chapter006/level005/scene.txt
+++ b/levels/missions/chapter006/level005/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/8_ServiceTower1_link.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=605 lost=0
+EndingFile win="other/win605.txt" lost="other/lost000.txt"
 
 Audio filename="music006.ogg"
 

--- a/levels/missions/chapter006/level006/scene.txt
+++ b/levels/missions/chapter006/level006/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/8_ServiceTower1_link.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music006.ogg"
 

--- a/levels/missions/chapter007/level001/scene.txt
+++ b/levels/missions/chapter007/level001/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/8_ServiceTower1_link.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music007.ogg"
 

--- a/levels/missions/chapter007/level002/scene.txt
+++ b/levels/missions/chapter007/level002/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/8_ServiceTower1_link.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music007.ogg"
 

--- a/levels/missions/chapter007/level003/scene.txt
+++ b/levels/missions/chapter007/level003/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/8_ServiceTower1_link.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music007.ogg"
 

--- a/levels/missions/chapter007/level004/scene.txt
+++ b/levels/missions/chapter007/level004/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/8_ServiceTower1_link.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=704 lost=0
+EndingFile win="other/win704.txt" lost="other/lost000.txt"
 
 AudioChange filename="Hv2.ogg" pos=0;0 dist=25000 type=Converter min=1 repeat=0
 

--- a/levels/missions/chapter007/level005/scene.txt
+++ b/levels/missions/chapter007/level005/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/8_ServiceTower1_link.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music007.ogg"
 

--- a/levels/missions/chapter008/level001/scene.txt
+++ b/levels/missions/chapter008/level001/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/8_ServiceTower1_link.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="Infinite.ogg" repeat=0
 

--- a/levels/missions/chapter008/level002/scene.txt
+++ b/levels/missions/chapter008/level002/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/8_ServiceTower1_link.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music008.ogg"
 

--- a/levels/missions/chapter009/level001/scene.txt
+++ b/levels/missions/chapter009/level001/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/9_terranova.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music009.ogg"
 

--- a/levels/missions/chapter009/level002/scene.txt
+++ b/levels/missions/chapter009/level002/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/8_ServiceTower1_link.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music009.ogg"
 

--- a/levels/missions/chapter009/level003/scene.txt
+++ b/levels/missions/chapter009/level003/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/8_ServiceTower1_link.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="Prototype.ogg" repeat=0
 

--- a/levels/missions/chapter009/level004/scene.txt
+++ b/levels/missions/chapter009/level004/scene.txt
@@ -5,7 +5,7 @@ Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/10_FollowPhazer.txt"
 SoluceFile name="%lvl%/help/soluce.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=904 lost=0
+EndingFile win="other/win904.txt" lost="other/lost000.txt"
 
 Audio filename="music009.ogg"
 

--- a/levels/plus/chapter001/level001/scene.txt
+++ b/levels/plus/chapter001/level001/scene.txt
@@ -2,7 +2,7 @@ Title.E text="Plan B"
 Resume.E text="Equip your spaceship and get ready for takeoff."
 Instructions name="%lvl%/help/help.%lng%.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 MessageDelay factor=2
 
 Audio filename="music002.ogg"

--- a/levels/plus/chapter002/level001/scene.txt
+++ b/levels/plus/chapter002/level001/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/1_SwitchCell1.txt"
 HelpFile name="cbot.txt"
-EndingFile win=201 lost=0
+EndingFile win="other/win201.txt" lost="other/lost000.txt"
 
 // Planets for SpaceShip transition animation
 Planet mode=1 pos=1.0;0.2 dim=0.50 speed=0.0 dir=0.3 image="planets/planet-earth.png" uv1=0.0;0.0 uv2=1.0;1.0

--- a/levels/plus/chapter002/level002/scene.txt
+++ b/levels/plus/chapter002/level002/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/1_SwitchCell1_link.txt"
 HelpFile name="cbot.txt"
-EndingFile win=202 lost=0
+EndingFile win="other/win202.txt" lost="other/lost000.txt"
 
 #Include file="%chap%/planet.txt"
 TerrainRelief image="relief03.png" factor=1.0

--- a/levels/plus/chapter002/level003/scene.txt
+++ b/levels/plus/chapter002/level003/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/2_Recharge1.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 #Include file="%chap%/planet.txt"
 TerrainRelief image="relief13.png" factor=1.0

--- a/levels/plus/chapter003/level001/scene.txt
+++ b/levels/plus/chapter003/level001/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/3_Recharge2.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 AudioChange pos=0.00;0.00 dist=25000.00 tool=Shooter powermin=0.8 filename="Constructive.ogg" repeat=0
 

--- a/levels/plus/chapter003/level002/scene.txt
+++ b/levels/plus/chapter003/level002/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/3_Recharge2_link.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music003.ogg"
 

--- a/levels/plus/chapter003/level003/scene.txt
+++ b/levels/plus/chapter003/level003/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/3_Recharge2.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music003.ogg"
 

--- a/levels/plus/chapter004/level001/scene.txt
+++ b/levels/plus/chapter004/level001/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/4_CollectTitanium1.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music004.ogg"
 

--- a/levels/plus/chapter004/level002/scene.txt
+++ b/levels/plus/chapter004/level002/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/5_CollectTitanium2.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music004.ogg"
 

--- a/levels/plus/chapter004/level003/scene.txt
+++ b/levels/plus/chapter004/level003/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/5_CollectTitanium2_link.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music004.ogg"
 

--- a/levels/plus/chapter004/level004/scene.txt
+++ b/levels/plus/chapter004/level004/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/5_CollectTitanium2_link.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music004.ogg"
 

--- a/levels/plus/chapter005/level001/scene.txt
+++ b/levels/plus/chapter005/level001/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/5_CollectTitanium2_link.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music005.ogg"
 

--- a/levels/plus/chapter005/level002/scene.txt
+++ b/levels/plus/chapter005/level002/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/6_KillAnt1.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="Quite.ogg"
 

--- a/levels/plus/chapter005/level003/scene.txt
+++ b/levels/plus/chapter005/level003/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/6_KillAnt1_link.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music005.ogg"
 

--- a/levels/plus/chapter006/level001/scene.txt
+++ b/levels/plus/chapter006/level001/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/7_CollectTitanium3.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music006.ogg"
 

--- a/levels/plus/chapter006/level002/scene.txt
+++ b/levels/plus/chapter006/level002/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/7_CollectTitanium3_link.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music006.ogg"
 

--- a/levels/plus/chapter006/level003/scene.txt
+++ b/levels/plus/chapter006/level003/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/8_ServiceTower1.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music006.ogg"
 

--- a/levels/plus/chapter006/level004/scene.txt
+++ b/levels/plus/chapter006/level004/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/8_ServiceTower1_link.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music006.ogg"
 

--- a/levels/plus/chapter006/level005/scene.txt
+++ b/levels/plus/chapter006/level005/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/8_ServiceTower1_link.txt"
 HelpFile name="cbot.txt"
-EndingFile win=604 lost=0
+EndingFile win="other/win604.txt" lost="other/lost000.txt"
 
 Audio filename="music006.ogg"
 

--- a/levels/plus/chapter006/level006/scene.txt
+++ b/levels/plus/chapter006/level006/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/8_ServiceTower1_link.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music006.ogg"
 

--- a/levels/plus/chapter007/level001/scene.txt
+++ b/levels/plus/chapter007/level001/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/8_ServiceTower1_link.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music007.ogg"
 

--- a/levels/plus/chapter007/level002/scene.txt
+++ b/levels/plus/chapter007/level002/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/8_ServiceTower1_link.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music007.ogg"
 

--- a/levels/plus/chapter007/level003/scene.txt
+++ b/levels/plus/chapter007/level003/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/8_ServiceTower1_link.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music007.ogg"
 

--- a/levels/plus/chapter007/level004/scene.txt
+++ b/levels/plus/chapter007/level004/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/8_ServiceTower1_link.txt"
 HelpFile name="cbot.txt"
-EndingFile win=704 lost=0
+EndingFile win="other/win704.txt" lost="other/lost000.txt"
 
 AudioChange filename="Hv2.ogg" pos=0;0 dist=25000 type=Converter min=1 repeat=0
 

--- a/levels/plus/chapter007/level005/scene.txt
+++ b/levels/plus/chapter007/level005/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/8_ServiceTower1_link.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music007.ogg"
 

--- a/levels/plus/chapter008/level001/scene.txt
+++ b/levels/plus/chapter008/level001/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/8_ServiceTower1_link.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="Infinite.ogg" repeat=0
 

--- a/levels/plus/chapter008/level002/scene.txt
+++ b/levels/plus/chapter008/level002/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/8_ServiceTower1_link.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music008.ogg"
 

--- a/levels/plus/chapter009/level001/scene.txt
+++ b/levels/plus/chapter009/level001/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/9_terranova.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music009.ogg"
 

--- a/levels/plus/chapter009/level002/scene.txt
+++ b/levels/plus/chapter009/level002/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/8_ServiceTower1_link.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="music009.ogg"
 

--- a/levels/plus/chapter009/level003/scene.txt
+++ b/levels/plus/chapter009/level003/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/8_ServiceTower1_link.txt"
 HelpFile name="cbot.txt"
-EndingFile win=-1 lost=0
+EndingFile lost="other/lost000.txt"
 
 Audio filename="Prototype.ogg" repeat=0
 

--- a/levels/plus/chapter009/level004/scene.txt
+++ b/levels/plus/chapter009/level004/scene.txt
@@ -4,7 +4,7 @@ Instructions name="%lvl%/help/help.%lng%.txt"
 Satellite name="%lvl%/help/report.%lng%.txt"
 Loading name="programs/10_FollowPhazer.txt"
 HelpFile name="cbot.txt"
-EndingFile win=904 lost=0
+EndingFile win="other/win904.txt" lost="other/lost000.txt"
 
 Audio filename="music009.ogg"
 


### PR DESCRIPTION
https://github.com/colobot/colobot/commit/250047579f3e23071507e461cf616c366125693b deprecated the `EndingFile win=1 lost=0` syntax. It should now be `EndingFile win="other/win001.txt" lost="other/lost000.txt"`.

```bash
shopt -s globstar
perl -i -pe'/^EndingFile/ && /win=([0-9]+)/ && ($win=$1) && /(lost=([0-9]+))/ && ($_ = sprintf(qq(EndingFile win="levels/other/win%03d.txt" lost="levels/other/lost%03d.txt"\n), $win, $1))' **/*.txt
sed -i -E '/^EndingFile win=-1 lost=-1$/d' **/*.txt
sed -i -E 's%^EndingFile win=-1 lost=0$%EndingFile lost="levels/other/lost000.txt"%' **/*.txt
sed -i 's%levels/other/%other/%' **/*.txt  # it turns out that colobot automatically prepends levels/ to the path
```