### PR TITLE
Fix instructions in 2-1 "Titanium ore"

### DIFF
--- a/levels/missions/chapter002/level001/help/help.E.txt
+++ b/levels/missions/chapter002/level001/help/help.E.txt
@@ -8,7 +8,7 @@ We have transmitted to your \l;spaceship\u object\base; a program that might hel
 \b;Procedure
 1) A new \l;research program\u object\research; is required for winged bots to be added to the list of bots that can be produced by the factory. This research program will also make the propulsion reactor in your personal survival kit operational.
 2) Produce a \l;winged grabber\u object\botgj; and collect the 4 chunks of \l;titanium ore\u object\titanore;.
-3) Take the \l;winged grabber\u object\botgj; and the \l;wheeled grabber\u object\botgr; along with you and take off. 
+3) Bring the \l;winged grabber\u object\botgj; and the \l;wheeled grabber\u object\botgr; back aboard your \l;spaceship\u object\base;.
 
 Be careful that your winged bot does not run out of power when you are far from base. If necessary, replace the \l;power cell\u object\power; before leaving the spaceship. You can either do this manually or you can execute the enclosed program provided by Houston \button 53;.
 


### PR DESCRIPTION
The game tells you to take off, but:
1. The mission ends as soon as the ore and both bots are in range of the ship
1. The next mission is in the same location on the same planet -> You did not actually fly anywhere -> scene.txt not requiring the player to press "take off" is not a bug -> The instructions need to be fixed