### PR TITLE
Made AlienNest invulnerable in missions that require it

### DIFF
--- a/levels/missions/chapter006/level002/scene.txt
+++ b/levels/missions/chapter006/level002/scene.txt
@@ -32,7 +32,7 @@ CreateObject pos=40.00;-71.25 dir=0.0 type=Titanium
 CreateObject pos=41.25;-71.25 dir=0.0 type=Titanium
 //CreateObject pos=0;-75 dir=0.2 type=AlienEgg autoValue1=30 autoType=AlienWasp autoString="wasp01.txt" run=1
 
-CreateObject pos=42.0;100.0 dir=0.0 type=AlienNest
+CreateObject pos=42.0;100.0 dir=0.0 type=AlienNest magnifyDamage=0
 CreateObject pos= 45; 100 cmdline= 42; 100; 15; 2.0 dir=0.0 type=AlienAnt script1="anticv.txt" run=1
 CreateObject pos= 40; 100 cmdline= 42; 100; 15; 2.0 dir=0.0 type=AlienAnt script1="anticv.txt" run=1
 CreateObject pos= 45; 105 cmdline= 42; 100; 15; 2.0 dir=0.0 type=AlienAnt script1="anticv.txt" run=1

--- a/levels/missions/chapter007/level001/scene.txt
+++ b/levels/missions/chapter007/level001/scene.txt
@@ -84,7 +84,7 @@ CreateObject pos=158; 99 dir=0.2 type=UraniumOre
 CreateObject pos=170;106 dir=0.1 type=UraniumOre
 CreateObject pos=172; 91 dir=0.3 type=UraniumOre
 
-CreateObject pos=149;-220 dir=0.0 type=AlienNest
+CreateObject pos=149;-220 dir=0.0 type=AlienNest magnifyDamage=0
 CreateObject pos=148;-215 dir=0.2 type=Greenery4
 CreateObject pos=145;-222 dir=0.5 type=Greenery3
 CreateObject pos=146;-227 dir=0.0 type=Greenery2

--- a/levels/plus/chapter006/level003/scene.txt
+++ b/levels/plus/chapter006/level003/scene.txt
@@ -32,7 +32,7 @@ CreateObject pos=40.00;-71.25 dir=0.0 type=Titanium
 CreateObject pos=41.25;-71.25 dir=0.0 type=Titanium
 //CreateObject pos=0;-75 dir=0.2 type=AlienEgg autoValue1=30 autoType=AlienWasp autoString="wasp01.txt" run=1
 
-CreateObject pos=42.0;100.0 dir=0.0 type=AlienNest
+CreateObject pos=42.0;100.0 dir=0.0 type=AlienNest magnifyDamage=0
 CreateObject pos= 45; 100 cmdline= 42; 100; 15; 2.0 dir=0.0 type=AlienAnt script1="anticv.txt" run=1
 CreateObject pos= 40; 100 cmdline= 42; 100; 15; 2.0 dir=0.0 type=AlienAnt script1="anticv.txt" run=1
 CreateObject pos= 45; 105 cmdline= 42; 100; 15; 2.0 dir=0.0 type=AlienAnt script1="anticv.txt" run=1

--- a/levels/plus/chapter007/level001/scene.txt
+++ b/levels/plus/chapter007/level001/scene.txt
@@ -84,7 +84,7 @@ CreateObject pos=158; 99 dir=0.2 type=UraniumOre
 CreateObject pos=170;106 dir=0.1 type=UraniumOre
 CreateObject pos=172; 91 dir=0.3 type=UraniumOre
 
-CreateObject pos=149;-220 dir=0.0 type=AlienNest
+CreateObject pos=149;-220 dir=0.0 type=AlienNest magnifyDamage=0
 CreateObject pos=148;-215 dir=0.2 type=Greenery4
 CreateObject pos=145;-222 dir=0.5 type=Greenery3
 CreateObject pos=146;-227 dir=0.0 type=Greenery2


### PR DESCRIPTION
* https://github.com/colobot/colobot/pull/1742 makes AlienNest destroyable by default. There are 4 missions (two normal and two new game plus), where it needs to be invulnerable to avoid softlock.