### PR TITLE
0.2.2 Fix installation of converted ogg files

### DIFF
--- a/music/CMakeLists.txt
+++ b/music/CMakeLists.txt
@@ -94,11 +94,11 @@ if(MUSIC)
                 message(STATUS "Adding OGG convert target for ${FILE}")
 
                 execute_process(
-                    COMMAND ${OGGENC} -q ${MUSIC_QUALITY} -o "${FILENAME}.ogg" "${DOWNLOAD_FILE_LOC}"
+                    COMMAND ${OGGENC} -q ${MUSIC_QUALITY} -o "${CMAKE_CURRENT_BINARY_DIR}/${FILENAME}.ogg" "${DOWNLOAD_FILE_LOC}"
                 )
 
                 install(FILES
-                    ${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}.ogg
+                    ${CMAKE_CURRENT_BINARY_DIR}/${FILENAME}.ogg
                     DESTINATION ${COLOBOT_INSTALL_MUSIC_DIR}
                 )
             endif()


### PR DESCRIPTION
0.2.2's build does not seem to have been tested with the conversion of FLAC files to OGG files; installation fails.

This patch fixes this.