### PR TITLE
Update Czech translation

### DIFF
--- a/help/cbot/po/cbot.pot
+++ b/help/cbot/po/cbot.pot
@@ -53,13 +53,13 @@ msgid "Time in seconds."
 msgstr ""
 
 #. type: \t; header
-#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:197 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:79 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
+#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:198 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:83 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
 #, no-wrap
 msgid "See also"
 msgstr ""
 
 #. type: Plain text
-#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:198 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:80 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
+#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:199 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:84 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
 #, no-wrap
 msgid "<a cbot>Programming</a>, <a cbot|type>types</a> and <a cbot|category>categories</a>."
 msgstr ""
@@ -510,7 +510,7 @@ msgid "Conditions"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:116
+#: ../E/expr.txt:117
 #, no-wrap
 msgid ""
 "<code>a == b  </code><code>a</code> equals <code>b</code>\n"
@@ -522,7 +522,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:124
+#: ../E/expr.txt:125
 #, no-wrap
 msgid ""
 "<code>12 == 12  </code>returns true\n"
@@ -534,13 +534,13 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:132
+#: ../E/expr.txt:133
 #, no-wrap
 msgid "Be careful not to confuse the equality comparison <code>==</code> with the assignment of a <a cbot|var>variable</a> <code>=</code>."
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:134
+#: ../E/expr.txt:135
 #, no-wrap
 msgid ""
 "<code>a == b</code> is an expression that compares <code>a</code> with <code>b</code>.\n"
@@ -1080,24 +1080,13 @@ msgid "Expressions"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:86
+#: ../E/expr.txt:87
 #, no-wrap
 msgid "is equivalent to"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:90
-#, no-wrap
-msgid ""
-"<code>+=</code>  addition\n"
-"<code>-=</code>  subtraction\n"
-"<code>*=</code>  multiplication\n"
-"<code>/=</code>  division\n"
-"<code>%=</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
-msgstr ""
-
-#. type: Plain text
-#: ../E/expr.txt:178
+#: ../E/expr.txt:179
 #, no-wrap
 msgid "The operators <code>++</code> and <code>--</code> allow you to increment (++) or to decrement (--) a variable in very compact and efficient manner."
 msgstr ""
@@ -2090,79 +2079,79 @@ msgid "Type <code>object</code>"
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:21
+#: ../E/object.txt:22
 #, no-wrap
 msgid "<code>category</code>"
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:24
+#: ../E/object.txt:25
 #, no-wrap
 msgid "<code>position</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:25
+#: ../E/object.txt:26
 #, no-wrap
 msgid "Position of the object on the planet, in meters. The coordinates <code>x</code> and <code>y</code> correspond to the location on a map, the <code>z</code> coordinate corresponds to the altitude above (respectively below) sea level. "
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:27
+#: ../E/object.txt:28
 #, no-wrap
 msgid "<code>orientation</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:28
+#: ../E/object.txt:29
 #, no-wrap
 msgid "Orientation of the object, in degrees. The orientation tells you what direction the object is facing. An orientation of <code>0</code> corresponds to an object facing eastwards, thus following the positive <code>x</code> axis. The orientation is measured counterclockwise. "
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:30
+#: ../E/object.txt:31
 #, no-wrap
 msgid "<code>pitch</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:31
+#: ../E/object.txt:32
 #, no-wrap
 msgid "Forward/backward angle of the robot. A pitch of <code>0</code> means that the bot is standing on flat ground. A positive inclination means that it is facing upwards, a negative inclination means that it is facing downwards. "
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:33
+#: ../E/object.txt:34
 #, no-wrap
 msgid "<code>roll</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:34
+#: ../E/object.txt:35
 #, no-wrap
 msgid "Left/right angle of the bot, in degrees. A positive value means that the bot is leaning to the left side, a negative value means that it is leaning to the right side. "
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:36
+#: ../E/object.txt:37
 #, no-wrap
 msgid "<code>energyLevel</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:37
+#: ../E/object.txt:38
 #, no-wrap
 msgid "Energy level, between 0 and 1. A normal <a object|power>power cell</a> that is fully charged returns the value <code>1</code>. A <a object|atomic>nuclear power cell</a> never returns a value higher than 1, it just lasts longer. Attention: The energy level of a bot is always zero, because the energy is not contained in the bot, but in the power cell. To know the energy level of the power cell of a bot, you must write <code>energyCell.energyLevel</code>. "
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:39
+#: ../E/object.txt:40
 #, no-wrap
 msgid "<code>shieldLevel</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:40
+#: ../E/object.txt:41
 #, no-wrap
 msgid ""
 "Shield level of a robot or building. A level <code>1</code> indicates that the shield is still perfect. Every time that the bot or building gets a bullet or collides with another object, the shield level decreases. When the level reaches <code>0</code>, the next bullet or collision will destroy the bot or building. \n"
@@ -2170,49 +2159,49 @@ msgid ""
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:43
+#: ../E/object.txt:44
 #, no-wrap
 msgid "<code>temperature</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:44
+#: ../E/object.txt:45
 #, no-wrap
 msgid "Temperature of the jet of <a object|botgj>winged bots</a>. <code>0</code> corresponds to a cold jet. When used, the temperature increases progressively. When it reaches the value <code>1</code>, the jet is overheated and stops working, until it cooled down a little. "
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:46
+#: ../E/object.txt:47
 #, no-wrap
 msgid "<code>altitude</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:47
+#: ../E/object.txt:48
 #, no-wrap
 msgid "The <code>z</code> coordinate of the position indicates the altitude above sea level, whereas the <code>altitude</code> indicates the height above ground. This value is meaningful only for <a object|botgj>winged bots</a> and for <a object|wasp>wasps</a>. For all other objects, this value is zero. "
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:49
+#: ../E/object.txt:50
 #, no-wrap
 msgid "<code>lifeTime</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:50
+#: ../E/object.txt:51
 #, no-wrap
 msgid "The age of the object in seconds since it's creation."
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:52
+#: ../E/object.txt:53
 #, no-wrap
 msgid "<code>energyCell</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:53
+#: ../E/object.txt:54
 #, no-wrap
 msgid ""
 "This information is special, because it returns the information about another object, in this case the power pack. This means that energyCell contains all the characteristics of a normal object, for example <code>category</code> (PowerCell or NuclearCell), <code>position</code> (the position of the cell), etc.\n"
@@ -2221,31 +2210,31 @@ msgid ""
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:57
+#: ../E/object.txt:58
 #, no-wrap
 msgid "<code>load</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:58
+#: ../E/object.txt:59
 #, no-wrap
 msgid "This information also returns the description of a whole object: the description of the object carried by a <a object|botgr>grabber</a>. If it carries nothing, <code>load</code> returns <code>null</code>."
 msgstr ""
 
 #. type: \t; header, \b; header
-#: ../E/expr.txt:99 ../E/expr.txt:123 ../E/expr.txt:145 ../E/expr.txt:170 ../E/expr.txt:187 ../E/factory.txt:21 ../E/object.txt:66
+#: ../E/expr.txt:100 ../E/expr.txt:124 ../E/expr.txt:146 ../E/expr.txt:171 ../E/expr.txt:188 ../E/factory.txt:21 ../E/object.txt:70
 #, no-wrap
 msgid "Examples"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:67
+#: ../E/object.txt:71
 #, no-wrap
 msgid "The type <code>object</code> returns the special value <code><a cbot|null>null</a></code> when the object does not exist. For example:"
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:69
+#: ../E/object.txt:73
 #, no-wrap
 msgid ""
 "\tobject a;\n"
@@ -2751,7 +2740,7 @@ msgid "Returns the first object found that corresponds to the specified category
 msgstr ""
 
 #. type: \t; header
-#: ../E/expr.txt:131 ../E/radar.txt:68
+#: ../E/expr.txt:132 ../E/radar.txt:68
 #, no-wrap
 msgid "Remark"
 msgstr ""
@@ -5664,57 +5653,37 @@ msgid "Use this type for variables that contain the characteristics of an object
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:4
-#, no-wrap
-msgid ""
-"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
-"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
-"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
-"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
-"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
-"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
-"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
-"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
-"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
-"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
-"<code>object object.energyCell   </code>Power cell on the bot\n"
-"<code>object object.load         </code>Object carried by the bot\n"
-"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
-"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object"
-msgstr ""
-
-#. type: Plain text
-#: ../E/object.txt:19
+#: ../E/object.txt:20
 #, no-wrap
 msgid "Also, some objects have additional methods (instructions). See them in <a cbot>the main list</a> in the <c/>\"Instructions specific for some objects\" section."
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:22
+#: ../E/object.txt:23
 #, no-wrap
 msgid "The <n/><a cbot|category>category</a> of an object allows you to know what it is, f. ex. what kind of bot, building, enemy, etc."
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:60
+#: ../E/object.txt:61
 #, no-wrap
 msgid "<code>team</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:61
+#: ../E/object.txt:62
 #, no-wrap
 msgid "The bot's team. Used in <a battles>code battles</a>. If the object has no team assigned (e.g. in no team-based levels, the object being a resource), this is equal to <code>0</code>."
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:63
+#: ../E/object.txt:64
 #, no-wrap
 msgid "<code>velocity</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:64
+#: ../E/object.txt:65
 #, no-wrap
 msgid "Current velocity of the object. Should be treated as a three-dimensional vector."
 msgstr ""
@@ -6625,20 +6594,9 @@ msgid "Binary operators below are working with fundamental number types (<code><
 msgstr ""
 
 #. type: \t; header
-#: ../E/expr.txt:53 ../E/expr.txt:89 ../E/expr.txt:115 ../E/expr.txt:140 ../E/expr.txt:163
+#: ../E/expr.txt:53 ../E/expr.txt:90 ../E/expr.txt:116 ../E/expr.txt:141 ../E/expr.txt:164
 #, no-wrap
 msgid "List"
-msgstr ""
-
-#. type: Plain text
-#: ../E/expr.txt:54
-#, no-wrap
-msgid ""
-"<code>+</code>  addition\n"
-"<code>-</code>  subtraction\n"
-"<code>*</code>  multiplication\n"
-"<code>/</code>  division\n"
-"<code>%</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
 msgstr ""
 
 #. type: \t; header
@@ -6666,49 +6624,49 @@ msgid "Real life examples"
 msgstr ""
 
 #. type: \t; header
-#: ../E/expr.txt:81
+#: ../E/expr.txt:82
 #, no-wrap
 msgid "Compound assignment operators"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:82
+#: ../E/expr.txt:83
 #, no-wrap
 msgid "Besides the <code>=</code> operator for variable assignment there are several compound-assignment operators."
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:84
+#: ../E/expr.txt:85
 #, no-wrap
 msgid "The compound-assignment operators combine the <code>=</code> assignment operator with another binary operator such as <code>+</code> or <code>-</code>. Compound-assignment operators perform the operation specified by the additional operator and then assign the result to the left operand. For example, a compound-assignment expression such as"
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:85
+#: ../E/expr.txt:86
 #, no-wrap
 msgid "<code>lvalue += expression</code>"
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:87
+#: ../E/expr.txt:88
 #, no-wrap
 msgid "<code>lvalue = lvalue + expression</code>"
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:96
+#: ../E/expr.txt:97
 #, no-wrap
 msgid "String concatenation"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:97
+#: ../E/expr.txt:98
 #, no-wrap
 msgid "If at least one of the values used with the <code>+</code> operator is a <a cbot|string>string</a>, then the operation of concatenation is performed. The result of the operator is then a string, which is created by joining end-to-end the string and the other value. If the other value is not a string, then it is converted to string beforehand."
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:101
+#: ../E/expr.txt:102
 #, no-wrap
 msgid ""
 "\tstring s = \"a\" + \"bc\";  // returns \"abc\"\n"
@@ -6718,43 +6676,43 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:106
+#: ../E/expr.txt:107
 #, no-wrap
 msgid "Tip: the properties of the concatenation <code>+</code> operator is useful with the <a cbot|message>message();</a> function, because it does not work with other types than string. An empty string can be used together with a value in order to create a string, which actually can be passed to the <a cbot|message>message();</a> function:"
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:177
+#: ../E/expr.txt:178
 #, no-wrap
 msgid "Prefix and postfix increment- and decrement operators"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:180
+#: ../E/expr.txt:181
 #, no-wrap
 msgid "For example to increment the variable <code>a</code> you can write"
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:181
+#: ../E/expr.txt:182
 #, no-wrap
 msgid "<c/>a++;<n/>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:182
+#: ../E/expr.txt:183
 #, no-wrap
 msgid "instead of"
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:183
+#: ../E/expr.txt:184
 #, no-wrap
 msgid "<c/>a = a + 1;<n/>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:185
+#: ../E/expr.txt:186
 #, no-wrap
 msgid "The result of the operation <code>a++</code> is the value of the variable <code>a</code> *before* the increment. If you use the prefix operator <code>++a</code> the result of the operation is the value of the variable <code>a</code> *after* the increment. The same holds for the <code>--</code> decrement operator."
 msgstr ""
@@ -6778,27 +6736,7 @@ msgid "Note: it may be not obvious at first, but notice that <code>=</code> is a
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:66
-#, no-wrap
-msgid ""
-" int    i = 12 + 3;      // i == 15\n"
-" int    i = 2 - 5;       // i == -3\n"
-" \n"
-" float  f = 3.01 * 10;   // f == 30.1\n"
-" \n"
-" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
-" float  f = 5 / 3;       // f == 1.67\n"
-" float  f = 5 / 0;       // returns an error (division by zero)\n"
-" \n"
-" int    i = 13 % 5;      // i == 3\n"
-" int    i = -8 % 3;      // i == -2\n"
-" \n"
-" float  f = sin(90) * i; // f == -2.0\n"
-" "
-msgstr ""
-
-#. type: Source code
-#: ../E/expr.txt:108
+#: ../E/expr.txt:109
 #, no-wrap
 msgid ""
 " float pi = 3.14;\n"
@@ -6807,7 +6745,7 @@ msgid ""
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:189
+#: ../E/expr.txt:190
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -6816,7 +6754,7 @@ msgid ""
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:193
+#: ../E/expr.txt:194
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -6825,25 +6763,25 @@ msgid ""
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:137
+#: ../E/expr.txt:138
 #, no-wrap
 msgid "Logical operators"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:138
+#: ../E/expr.txt:139
 #, no-wrap
 msgid "Logical operators work with values of type <a cbot|bool>bool</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:150
+#: ../E/expr.txt:151
 #, no-wrap
 msgid "Ternary operator"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:151
+#: ../E/expr.txt:152
 #, no-wrap
 msgid ""
 "The ternary operator is nothing more than a syntax sugar. It is also known as \"inline if\". It might be confusing at first, because its syntax is a little more complicated than other operators. It can be described as follows:\n"
@@ -6852,19 +6790,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:155
+#: ../E/expr.txt:156
 #, no-wrap
 msgid "Firstly, the condition is valued and then the first result is returned if the condition is true, otherwise the second result is returned."
 msgstr ""
 
 #. type: \t; header
-#: ../E/expr.txt:157 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
+#: ../E/expr.txt:158 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
 #, no-wrap
 msgid "Example"
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:158
+#: ../E/expr.txt:159
 #, no-wrap
 msgid "<c/>float c = ((3.0 > 2.0) ? 10.0 : -10.0); // c == 10.0<n/>"
 msgstr ""
@@ -6876,19 +6814,19 @@ msgid "A condition is a special <a cbot|expr>expression</a> that returns a <a cb
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:112
+#: ../E/expr.txt:113
 #, no-wrap
 msgid "Comparison operators"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:113
+#: ../E/expr.txt:114
 #, no-wrap
 msgid "Comparison operators work with values of type <a cbot|bool>float</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:141
+#: ../E/expr.txt:142
 #, no-wrap
 msgid ""
 "<code>!a      </code>not <code>a</code>\n"
@@ -6897,7 +6835,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:146
+#: ../E/expr.txt:147
 #, no-wrap
 msgid ""
 "<code>!false        </code>returns true\n"
@@ -6906,19 +6844,19 @@ msgid ""
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:160
+#: ../E/expr.txt:161
 #, no-wrap
 msgid "Bitwise operators"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:161
+#: ../E/expr.txt:162
 #, no-wrap
 msgid "Bitwise operators are similar to the logical operator, because they are operating on bits (which can be only 0 or 1, conditions can have a value only of false or true). So in theory, they should be working with basically any type of variable, because each value in the computer must be stored as a sequence of bits."
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:164
+#: ../E/expr.txt:165
 #, no-wrap
 msgid ""
 "<code>a & b  </code><code>a</code> AND <code>b</code>\n"
@@ -6929,7 +6867,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:171
+#: ../E/expr.txt:172
 #, no-wrap
 msgid ""
 "<code>2 & 1         </code>returns 0\n"
@@ -8211,4 +8149,80 @@ msgid ""
 " {\n"
 "     factory(WheeledGrabber, \"program/say-foo.cbot\");\n"
 " }"
+msgstr ""
+
+#. type: Plain text
+#: ../E/expr.txt:54
+#, no-wrap
+msgid ""
+"<code>+</code>  addition\n"
+"<code>-</code>  subtraction\n"
+"<code>*</code>  multiplication\n"
+"<code>/</code>  division\n"
+"<code>%</code>  remainder of the division (works for <code><a cbot|int>int</a></code> as well as <code><a cbot|float>float</a></code>)"
+msgstr ""
+
+#. type: Source code
+#: ../E/expr.txt:66
+#, no-wrap
+msgid ""
+" int    i = 12 + 3;      // i == 15\n"
+" int    i = 2 - 5;       // i == -3\n"
+" \n"
+" float  f = 3.01 * 10;   // f == 30.1\n"
+" \n"
+" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
+" float  f = 5 / 3;       // f == 1.67\n"
+" float  f = 5 / 0;       // returns an error (division by zero)\n"
+" \n"
+" int    i = 13 % 5;      // i == 3\n"
+" int    i = -8 % 3;      // i == -2\n"
+" float  f = -4.5 % 2.75; // f == -1.75\n"
+" \n"
+" float  f = sin(90) * i; // f == -2.0\n"
+" "
+msgstr ""
+
+#. type: Plain text
+#: ../E/expr.txt:91
+#, no-wrap
+msgid ""
+"<code>+=</code>  addition\n"
+"<code>-=</code>  subtraction\n"
+"<code>*=</code>  multiplication\n"
+"<code>/=</code>  division\n"
+"<code>%=</code>  remainder of the division"
+msgstr ""
+
+#. type: Plain text
+#: ../E/object.txt:4
+#, no-wrap
+msgid ""
+"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
+"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
+"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
+"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
+"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
+"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
+"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
+"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
+"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
+"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
+"<code>object object.energyCell   </code>Power cell on the bot\n"
+"<code>object object.load         </code>Object carried by the bot\n"
+"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
+"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object\n"
+"<code><a cbot|bool>bool</a>   object.dead         </code>Is the object dead?"
+msgstr ""
+
+#. type: Source code
+#: ../E/object.txt:67
+#, no-wrap
+msgid "<code>dead</code>"
+msgstr ""
+
+#. type: Plain text
+#: ../E/object.txt:68
+#, no-wrap
+msgid "True if the object was recently killed (while the death animation is playing). Note that accessing this property or any other property after the death animation finishes will cause an error that stops the program."
 msgstr ""

--- a/help/cbot/po/cbot.pot
+++ b/help/cbot/po/cbot.pot
@@ -53,13 +53,13 @@ msgid "Time in seconds."
 msgstr ""
 
 #. type: \t; header
-#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:198 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:83 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
+#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:197 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:79 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
 #, no-wrap
 msgid "See also"
 msgstr ""
 
 #. type: Plain text
-#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:199 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:84 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
+#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:198 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:80 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
 #, no-wrap
 msgid "<a cbot>Programming</a>, <a cbot|type>types</a> and <a cbot|category>categories</a>."
 msgstr ""
@@ -510,7 +510,7 @@ msgid "Conditions"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:117
+#: ../E/expr.txt:116
 #, no-wrap
 msgid ""
 "<code>a == b  </code><code>a</code> equals <code>b</code>\n"
@@ -522,7 +522,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:125
+#: ../E/expr.txt:124
 #, no-wrap
 msgid ""
 "<code>12 == 12  </code>returns true\n"
@@ -534,13 +534,13 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:133
+#: ../E/expr.txt:132
 #, no-wrap
 msgid "Be careful not to confuse the equality comparison <code>==</code> with the assignment of a <a cbot|var>variable</a> <code>=</code>."
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:135
+#: ../E/expr.txt:134
 #, no-wrap
 msgid ""
 "<code>a == b</code> is an expression that compares <code>a</code> with <code>b</code>.\n"
@@ -1080,13 +1080,24 @@ msgid "Expressions"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:87
+#: ../E/expr.txt:86
 #, no-wrap
 msgid "is equivalent to"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:179
+#: ../E/expr.txt:90
+#, no-wrap
+msgid ""
+"<code>+=</code>  addition\n"
+"<code>-=</code>  subtraction\n"
+"<code>*=</code>  multiplication\n"
+"<code>/=</code>  division\n"
+"<code>%=</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
+msgstr ""
+
+#. type: Plain text
+#: ../E/expr.txt:178
 #, no-wrap
 msgid "The operators <code>++</code> and <code>--</code> allow you to increment (++) or to decrement (--) a variable in very compact and efficient manner."
 msgstr ""
@@ -2079,79 +2090,79 @@ msgid "Type <code>object</code>"
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:22
+#: ../E/object.txt:21
 #, no-wrap
 msgid "<code>category</code>"
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:25
+#: ../E/object.txt:24
 #, no-wrap
 msgid "<code>position</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:26
+#: ../E/object.txt:25
 #, no-wrap
 msgid "Position of the object on the planet, in meters. The coordinates <code>x</code> and <code>y</code> correspond to the location on a map, the <code>z</code> coordinate corresponds to the altitude above (respectively below) sea level. "
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:28
+#: ../E/object.txt:27
 #, no-wrap
 msgid "<code>orientation</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:29
+#: ../E/object.txt:28
 #, no-wrap
 msgid "Orientation of the object, in degrees. The orientation tells you what direction the object is facing. An orientation of <code>0</code> corresponds to an object facing eastwards, thus following the positive <code>x</code> axis. The orientation is measured counterclockwise. "
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:31
+#: ../E/object.txt:30
 #, no-wrap
 msgid "<code>pitch</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:32
+#: ../E/object.txt:31
 #, no-wrap
 msgid "Forward/backward angle of the robot. A pitch of <code>0</code> means that the bot is standing on flat ground. A positive inclination means that it is facing upwards, a negative inclination means that it is facing downwards. "
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:34
+#: ../E/object.txt:33
 #, no-wrap
 msgid "<code>roll</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:35
+#: ../E/object.txt:34
 #, no-wrap
 msgid "Left/right angle of the bot, in degrees. A positive value means that the bot is leaning to the left side, a negative value means that it is leaning to the right side. "
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:37
+#: ../E/object.txt:36
 #, no-wrap
 msgid "<code>energyLevel</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:38
+#: ../E/object.txt:37
 #, no-wrap
 msgid "Energy level, between 0 and 1. A normal <a object|power>power cell</a> that is fully charged returns the value <code>1</code>. A <a object|atomic>nuclear power cell</a> never returns a value higher than 1, it just lasts longer. Attention: The energy level of a bot is always zero, because the energy is not contained in the bot, but in the power cell. To know the energy level of the power cell of a bot, you must write <code>energyCell.energyLevel</code>. "
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:40
+#: ../E/object.txt:39
 #, no-wrap
 msgid "<code>shieldLevel</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:41
+#: ../E/object.txt:40
 #, no-wrap
 msgid ""
 "Shield level of a robot or building. A level <code>1</code> indicates that the shield is still perfect. Every time that the bot or building gets a bullet or collides with another object, the shield level decreases. When the level reaches <code>0</code>, the next bullet or collision will destroy the bot or building. \n"
@@ -2159,49 +2170,49 @@ msgid ""
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:44
+#: ../E/object.txt:43
 #, no-wrap
 msgid "<code>temperature</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:45
+#: ../E/object.txt:44
 #, no-wrap
 msgid "Temperature of the jet of <a object|botgj>winged bots</a>. <code>0</code> corresponds to a cold jet. When used, the temperature increases progressively. When it reaches the value <code>1</code>, the jet is overheated and stops working, until it cooled down a little. "
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:47
+#: ../E/object.txt:46
 #, no-wrap
 msgid "<code>altitude</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:48
+#: ../E/object.txt:47
 #, no-wrap
 msgid "The <code>z</code> coordinate of the position indicates the altitude above sea level, whereas the <code>altitude</code> indicates the height above ground. This value is meaningful only for <a object|botgj>winged bots</a> and for <a object|wasp>wasps</a>. For all other objects, this value is zero. "
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:50
+#: ../E/object.txt:49
 #, no-wrap
 msgid "<code>lifeTime</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:51
+#: ../E/object.txt:50
 #, no-wrap
 msgid "The age of the object in seconds since it's creation."
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:53
+#: ../E/object.txt:52
 #, no-wrap
 msgid "<code>energyCell</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:54
+#: ../E/object.txt:53
 #, no-wrap
 msgid ""
 "This information is special, because it returns the information about another object, in this case the power pack. This means that energyCell contains all the characteristics of a normal object, for example <code>category</code> (PowerCell or NuclearCell), <code>position</code> (the position of the cell), etc.\n"
@@ -2210,31 +2221,31 @@ msgid ""
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:58
+#: ../E/object.txt:57
 #, no-wrap
 msgid "<code>load</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:59
+#: ../E/object.txt:58
 #, no-wrap
 msgid "This information also returns the description of a whole object: the description of the object carried by a <a object|botgr>grabber</a>. If it carries nothing, <code>load</code> returns <code>null</code>."
 msgstr ""
 
 #. type: \t; header, \b; header
-#: ../E/expr.txt:100 ../E/expr.txt:124 ../E/expr.txt:146 ../E/expr.txt:171 ../E/expr.txt:188 ../E/factory.txt:21 ../E/object.txt:70
+#: ../E/expr.txt:99 ../E/expr.txt:123 ../E/expr.txt:145 ../E/expr.txt:170 ../E/expr.txt:187 ../E/factory.txt:21 ../E/object.txt:66
 #, no-wrap
 msgid "Examples"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:71
+#: ../E/object.txt:67
 #, no-wrap
 msgid "The type <code>object</code> returns the special value <code><a cbot|null>null</a></code> when the object does not exist. For example:"
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:73
+#: ../E/object.txt:69
 #, no-wrap
 msgid ""
 "\tobject a;\n"
@@ -2740,7 +2751,7 @@ msgid "Returns the first object found that corresponds to the specified category
 msgstr ""
 
 #. type: \t; header
-#: ../E/expr.txt:132 ../E/radar.txt:68
+#: ../E/expr.txt:131 ../E/radar.txt:68
 #, no-wrap
 msgid "Remark"
 msgstr ""
@@ -5653,37 +5664,57 @@ msgid "Use this type for variables that contain the characteristics of an object
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:20
+#: ../E/object.txt:4
+#, no-wrap
+msgid ""
+"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
+"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
+"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
+"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
+"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
+"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
+"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
+"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
+"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
+"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
+"<code>object object.energyCell   </code>Power cell on the bot\n"
+"<code>object object.load         </code>Object carried by the bot\n"
+"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
+"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object"
+msgstr ""
+
+#. type: Plain text
+#: ../E/object.txt:19
 #, no-wrap
 msgid "Also, some objects have additional methods (instructions). See them in <a cbot>the main list</a> in the <c/>\"Instructions specific for some objects\" section."
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:23
+#: ../E/object.txt:22
 #, no-wrap
 msgid "The <n/><a cbot|category>category</a> of an object allows you to know what it is, f. ex. what kind of bot, building, enemy, etc."
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:61
+#: ../E/object.txt:60
 #, no-wrap
 msgid "<code>team</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:62
+#: ../E/object.txt:61
 #, no-wrap
 msgid "The bot's team. Used in <a battles>code battles</a>. If the object has no team assigned (e.g. in no team-based levels, the object being a resource), this is equal to <code>0</code>."
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:64
+#: ../E/object.txt:63
 #, no-wrap
 msgid "<code>velocity</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:65
+#: ../E/object.txt:64
 #, no-wrap
 msgid "Current velocity of the object. Should be treated as a three-dimensional vector."
 msgstr ""
@@ -6594,9 +6625,20 @@ msgid "Binary operators below are working with fundamental number types (<code><
 msgstr ""
 
 #. type: \t; header
-#: ../E/expr.txt:53 ../E/expr.txt:90 ../E/expr.txt:116 ../E/expr.txt:141 ../E/expr.txt:164
+#: ../E/expr.txt:53 ../E/expr.txt:89 ../E/expr.txt:115 ../E/expr.txt:140 ../E/expr.txt:163
 #, no-wrap
 msgid "List"
+msgstr ""
+
+#. type: Plain text
+#: ../E/expr.txt:54
+#, no-wrap
+msgid ""
+"<code>+</code>  addition\n"
+"<code>-</code>  subtraction\n"
+"<code>*</code>  multiplication\n"
+"<code>/</code>  division\n"
+"<code>%</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
 msgstr ""
 
 #. type: \t; header
@@ -6624,49 +6666,49 @@ msgid "Real life examples"
 msgstr ""
 
 #. type: \t; header
-#: ../E/expr.txt:82
+#: ../E/expr.txt:81
 #, no-wrap
 msgid "Compound assignment operators"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:83
+#: ../E/expr.txt:82
 #, no-wrap
 msgid "Besides the <code>=</code> operator for variable assignment there are several compound-assignment operators."
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:85
+#: ../E/expr.txt:84
 #, no-wrap
 msgid "The compound-assignment operators combine the <code>=</code> assignment operator with another binary operator such as <code>+</code> or <code>-</code>. Compound-assignment operators perform the operation specified by the additional operator and then assign the result to the left operand. For example, a compound-assignment expression such as"
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:86
+#: ../E/expr.txt:85
 #, no-wrap
 msgid "<code>lvalue += expression</code>"
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:88
+#: ../E/expr.txt:87
 #, no-wrap
 msgid "<code>lvalue = lvalue + expression</code>"
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:97
+#: ../E/expr.txt:96
 #, no-wrap
 msgid "String concatenation"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:98
+#: ../E/expr.txt:97
 #, no-wrap
 msgid "If at least one of the values used with the <code>+</code> operator is a <a cbot|string>string</a>, then the operation of concatenation is performed. The result of the operator is then a string, which is created by joining end-to-end the string and the other value. If the other value is not a string, then it is converted to string beforehand."
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:102
+#: ../E/expr.txt:101
 #, no-wrap
 msgid ""
 "\tstring s = \"a\" + \"bc\";  // returns \"abc\"\n"
@@ -6676,43 +6718,43 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:107
+#: ../E/expr.txt:106
 #, no-wrap
 msgid "Tip: the properties of the concatenation <code>+</code> operator is useful with the <a cbot|message>message();</a> function, because it does not work with other types than string. An empty string can be used together with a value in order to create a string, which actually can be passed to the <a cbot|message>message();</a> function:"
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:178
+#: ../E/expr.txt:177
 #, no-wrap
 msgid "Prefix and postfix increment- and decrement operators"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:181
+#: ../E/expr.txt:180
 #, no-wrap
 msgid "For example to increment the variable <code>a</code> you can write"
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:182
+#: ../E/expr.txt:181
 #, no-wrap
 msgid "<c/>a++;<n/>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:183
+#: ../E/expr.txt:182
 #, no-wrap
 msgid "instead of"
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:184
+#: ../E/expr.txt:183
 #, no-wrap
 msgid "<c/>a = a + 1;<n/>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:186
+#: ../E/expr.txt:185
 #, no-wrap
 msgid "The result of the operation <code>a++</code> is the value of the variable <code>a</code> *before* the increment. If you use the prefix operator <code>++a</code> the result of the operation is the value of the variable <code>a</code> *after* the increment. The same holds for the <code>--</code> decrement operator."
 msgstr ""
@@ -6736,7 +6778,27 @@ msgid "Note: it may be not obvious at first, but notice that <code>=</code> is a
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:109
+#: ../E/expr.txt:66
+#, no-wrap
+msgid ""
+" int    i = 12 + 3;      // i == 15\n"
+" int    i = 2 - 5;       // i == -3\n"
+" \n"
+" float  f = 3.01 * 10;   // f == 30.1\n"
+" \n"
+" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
+" float  f = 5 / 3;       // f == 1.67\n"
+" float  f = 5 / 0;       // returns an error (division by zero)\n"
+" \n"
+" int    i = 13 % 5;      // i == 3\n"
+" int    i = -8 % 3;      // i == -2\n"
+" \n"
+" float  f = sin(90) * i; // f == -2.0\n"
+" "
+msgstr ""
+
+#. type: Source code
+#: ../E/expr.txt:108
 #, no-wrap
 msgid ""
 " float pi = 3.14;\n"
@@ -6745,7 +6807,7 @@ msgid ""
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:190
+#: ../E/expr.txt:189
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -6754,7 +6816,7 @@ msgid ""
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:194
+#: ../E/expr.txt:193
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -6763,25 +6825,25 @@ msgid ""
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:138
+#: ../E/expr.txt:137
 #, no-wrap
 msgid "Logical operators"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:139
+#: ../E/expr.txt:138
 #, no-wrap
 msgid "Logical operators work with values of type <a cbot|bool>bool</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:151
+#: ../E/expr.txt:150
 #, no-wrap
 msgid "Ternary operator"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:152
+#: ../E/expr.txt:151
 #, no-wrap
 msgid ""
 "The ternary operator is nothing more than a syntax sugar. It is also known as \"inline if\". It might be confusing at first, because its syntax is a little more complicated than other operators. It can be described as follows:\n"
@@ -6790,19 +6852,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:156
+#: ../E/expr.txt:155
 #, no-wrap
 msgid "Firstly, the condition is valued and then the first result is returned if the condition is true, otherwise the second result is returned."
 msgstr ""
 
 #. type: \t; header
-#: ../E/expr.txt:158 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
+#: ../E/expr.txt:157 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
 #, no-wrap
 msgid "Example"
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:159
+#: ../E/expr.txt:158
 #, no-wrap
 msgid "<c/>float c = ((3.0 > 2.0) ? 10.0 : -10.0); // c == 10.0<n/>"
 msgstr ""
@@ -6814,19 +6876,19 @@ msgid "A condition is a special <a cbot|expr>expression</a> that returns a <a cb
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:113
+#: ../E/expr.txt:112
 #, no-wrap
 msgid "Comparison operators"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:114
+#: ../E/expr.txt:113
 #, no-wrap
 msgid "Comparison operators work with values of type <a cbot|bool>float</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:142
+#: ../E/expr.txt:141
 #, no-wrap
 msgid ""
 "<code>!a      </code>not <code>a</code>\n"
@@ -6835,7 +6897,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:147
+#: ../E/expr.txt:146
 #, no-wrap
 msgid ""
 "<code>!false        </code>returns true\n"
@@ -6844,19 +6906,19 @@ msgid ""
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:161
+#: ../E/expr.txt:160
 #, no-wrap
 msgid "Bitwise operators"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:162
+#: ../E/expr.txt:161
 #, no-wrap
 msgid "Bitwise operators are similar to the logical operator, because they are operating on bits (which can be only 0 or 1, conditions can have a value only of false or true). So in theory, they should be working with basically any type of variable, because each value in the computer must be stored as a sequence of bits."
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:165
+#: ../E/expr.txt:164
 #, no-wrap
 msgid ""
 "<code>a & b  </code><code>a</code> AND <code>b</code>\n"
@@ -6867,7 +6929,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:172
+#: ../E/expr.txt:171
 #, no-wrap
 msgid ""
 "<code>2 & 1         </code>returns 0\n"
@@ -8149,80 +8211,4 @@ msgid ""
 " {\n"
 "     factory(WheeledGrabber, \"program/say-foo.cbot\");\n"
 " }"
-msgstr ""
-
-#. type: Plain text
-#: ../E/expr.txt:54
-#, no-wrap
-msgid ""
-"<code>+</code>  addition\n"
-"<code>-</code>  subtraction\n"
-"<code>*</code>  multiplication\n"
-"<code>/</code>  division\n"
-"<code>%</code>  remainder of the division (works for <code><a cbot|int>int</a></code> as well as <code><a cbot|float>float</a></code>)"
-msgstr ""
-
-#. type: Source code
-#: ../E/expr.txt:66
-#, no-wrap
-msgid ""
-" int    i = 12 + 3;      // i == 15\n"
-" int    i = 2 - 5;       // i == -3\n"
-" \n"
-" float  f = 3.01 * 10;   // f == 30.1\n"
-" \n"
-" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
-" float  f = 5 / 3;       // f == 1.67\n"
-" float  f = 5 / 0;       // returns an error (division by zero)\n"
-" \n"
-" int    i = 13 % 5;      // i == 3\n"
-" int    i = -8 % 3;      // i == -2\n"
-" float  f = -4.5 % 2.75; // f == -1.75\n"
-" \n"
-" float  f = sin(90) * i; // f == -2.0\n"
-" "
-msgstr ""
-
-#. type: Plain text
-#: ../E/expr.txt:91
-#, no-wrap
-msgid ""
-"<code>+=</code>  addition\n"
-"<code>-=</code>  subtraction\n"
-"<code>*=</code>  multiplication\n"
-"<code>/=</code>  division\n"
-"<code>%=</code>  remainder of the division"
-msgstr ""
-
-#. type: Plain text
-#: ../E/object.txt:4
-#, no-wrap
-msgid ""
-"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
-"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
-"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
-"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
-"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
-"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
-"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
-"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
-"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
-"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
-"<code>object object.energyCell   </code>Power cell on the bot\n"
-"<code>object object.load         </code>Object carried by the bot\n"
-"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
-"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object\n"
-"<code><a cbot|bool>bool</a>   object.dead         </code>Is the object dead?"
-msgstr ""
-
-#. type: Source code
-#: ../E/object.txt:67
-#, no-wrap
-msgid "<code>dead</code>"
-msgstr ""
-
-#. type: Plain text
-#: ../E/object.txt:68
-#, no-wrap
-msgid "True if the object was recently killed (while the death animation is playing). Note that accessing this property or any other property after the death animation finishes will cause an error that stops the program."
 msgstr ""

--- a/help/cbot/po/cs.po
+++ b/help/cbot/po/cs.po
@@ -54,13 +54,13 @@ msgid "Time in seconds."
 msgstr "Čas v sekundách."
 
 #. type: \t; header
-#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:198 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:83 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
+#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:197 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:79 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
 #, no-wrap
 msgid "See also"
 msgstr "Užitečné odkazy"
 
 #. type: Plain text
-#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:199 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:84 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
+#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:198 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:80 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
 #, no-wrap
 msgid "<a cbot>Programming</a>, <a cbot|type>types</a> and <a cbot|category>categories</a>."
 msgstr "<a cbot>Programování</a>, <a cbot|type>datové typy</a> a <a cbot|category>kategorie</a>."
@@ -614,7 +614,7 @@ msgid "Conditions"
 msgstr "Podmínky"
 
 #. type: Plain text
-#: ../E/expr.txt:117
+#: ../E/expr.txt:116
 #, no-wrap
 msgid ""
 "<code>a == b  </code><code>a</code> equals <code>b</code>\n"
@@ -632,7 +632,7 @@ msgstr ""
 "<code>x >= y  </code><code>x</code> je větší nebo rovno <code>y</code>"
 
 #. type: Plain text
-#: ../E/expr.txt:125
+#: ../E/expr.txt:124
 #, no-wrap
 msgid ""
 "<code>12 == 12  </code>returns true\n"
@@ -650,13 +650,13 @@ msgstr ""
 "<code>12 >= 12  </code>vrátí true "
 
 #. type: Plain text
-#: ../E/expr.txt:133
+#: ../E/expr.txt:132
 #, no-wrap
 msgid "Be careful not to confuse the equality comparison <code>==</code> with the assignment of a <a cbot|var>variable</a> <code>=</code>."
 msgstr "Dávejte pozor, abyste si nespletli porovnání na rovnost <code>==</code> s přířazením do <a cbot|var>proměnné</a> <code>=</code>."
 
 #. type: Plain text
-#: ../E/expr.txt:135
+#: ../E/expr.txt:134
 #, no-wrap
 msgid ""
 "<code>a == b</code> is an expression that compares <code>a</code> with <code>b</code>.\n"
@@ -1256,13 +1256,29 @@ msgid "Expressions"
 msgstr "Výrazy"
 
 #. type: Plain text
-#: ../E/expr.txt:87
+#: ../E/expr.txt:86
 #, no-wrap
 msgid "is equivalent to"
 msgstr "dělá totéž jako"
 
 #. type: Plain text
-#: ../E/expr.txt:179
+#: ../E/expr.txt:90
+#, no-wrap
+msgid ""
+"<code>+=</code>  addition\n"
+"<code>-=</code>  subtraction\n"
+"<code>*=</code>  multiplication\n"
+"<code>/=</code>  division\n"
+"<code>%=</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
+msgstr ""
+"<code>+=</code>  sčítání\n"
+"<code>-=</code>  odčítání\n"
+"<code>*=</code>  násobení\n"
+"<code>/=</code>  dělení\n"
+"<code>%=</code>  zbytek po dělení (pouze pro datový typ <code><a cbot|int>int</a></code>)"
+
+#. type: Plain text
+#: ../E/expr.txt:178
 #, no-wrap
 msgid "The operators <code>++</code> and <code>--</code> allow you to increment (++) or to decrement (--) a variable in very compact and efficient manner."
 msgstr "Operátory <code>++</code> a <code>--</code> Vám umožňují stručně a jednoduše hodnotu proměnné zvýšit (++) nebo snížit (--) o jedničku."
@@ -2396,79 +2412,79 @@ msgid "Type <code>object</code>"
 msgstr "Datový typ <code>object</code>"
 
 #. type: Source code
-#: ../E/object.txt:22
+#: ../E/object.txt:21
 #, no-wrap
 msgid "<code>category</code>"
 msgstr "<code>category</code>"
 
 #. type: Source code
-#: ../E/object.txt:25
+#: ../E/object.txt:24
 #, no-wrap
 msgid "<code>position</code>"
 msgstr "<code>position</code>"
 
 #. type: Plain text
-#: ../E/object.txt:26
+#: ../E/object.txt:25
 #, no-wrap
 msgid "Position of the object on the planet, in meters. The coordinates <code>x</code> and <code>y</code> correspond to the location on a map, the <code>z</code> coordinate corresponds to the altitude above (respectively below) sea level. "
 msgstr "Poloha objektu na planetě, v metrech. Souřadnice <code>x</code> a <code>y</code> představují polohu na mapě, souřadnice <code>z</code> představuje nadmořskou výšku. "
 
 #. type: Source code
-#: ../E/object.txt:28
+#: ../E/object.txt:27
 #, no-wrap
 msgid "<code>orientation</code>"
 msgstr "<code>orientation</code>"
 
 #. type: Plain text
-#: ../E/object.txt:29
+#: ../E/object.txt:28
 #, no-wrap
 msgid "Orientation of the object, in degrees. The orientation tells you what direction the object is facing. An orientation of <code>0</code> corresponds to an object facing eastwards, thus following the positive <code>x</code> axis. The orientation is measured counterclockwise. "
 msgstr "Azimut objektu ve stupních. Tento atribut určuje, kterým směrem je objekt otočený. Azimut <code>0</code> znamená, že objekt směřuje na východ, tedy souběžně s kladnou poloosou <code>x</code>. Azimut se měří proti směru hodinových ručiček. "
 
 #. type: Source code
-#: ../E/object.txt:31
+#: ../E/object.txt:30
 #, no-wrap
 msgid "<code>pitch</code>"
 msgstr "<code>pitch</code>"
 
 #. type: Plain text
-#: ../E/object.txt:32
+#: ../E/object.txt:31
 #, no-wrap
 msgid "Forward/backward angle of the robot. A pitch of <code>0</code> means that the bot is standing on flat ground. A positive inclination means that it is facing upwards, a negative inclination means that it is facing downwards. "
 msgstr "Náklon objektu vpřed nebo vzad. Hodnota <code>0</code> znamená, že objekt se nachází ve vodorovné poloze. Kladná hodnota znamená náklon vzad (objekt míří čelem k nebi), záporná hodnota znamená náklon vpřed (objekt míří čelem do země). "
 
 #. type: Source code
-#: ../E/object.txt:34
+#: ../E/object.txt:33
 #, no-wrap
 msgid "<code>roll</code>"
 msgstr "<code>roll</code>"
 
 #. type: Plain text
-#: ../E/object.txt:35
+#: ../E/object.txt:34
 #, no-wrap
 msgid "Left/right angle of the bot, in degrees. A positive value means that the bot is leaning to the left side, a negative value means that it is leaning to the right side. "
 msgstr "Svislý náklon objektu vlevo nebo vpravo ve stupních. Kladná hodnota znamená, že objekt se naklání doleva, záporná hodnota znamená, že se naklání doprava. "
 
 #. type: Source code
-#: ../E/object.txt:37
+#: ../E/object.txt:36
 #, no-wrap
 msgid "<code>energyLevel</code>"
 msgstr "<code>energyLevel</code>"
 
 #. type: Plain text
-#: ../E/object.txt:38
+#: ../E/object.txt:37
 #, no-wrap
 msgid "Energy level, between 0 and 1. A normal <a object|power>power cell</a> that is fully charged returns the value <code>1</code>. A <a object|atomic>nuclear power cell</a> never returns a value higher than 1, it just lasts longer. Attention: The energy level of a bot is always zero, because the energy is not contained in the bot, but in the power cell. To know the energy level of the power cell of a bot, you must write <code>energyCell.energyLevel</code>. "
 msgstr "Stav baterie v rozsahu 0 až 1. Běžná plně nabitá <a object|power>baterie</a> zde bude mít hodnotu <code>1</code>. <a object|atomic>Jaderná baterie</a> zde také bude mít hodnotu nejvýše 1, ale vydrží mnohem déle. Pozor: robot zde bude mít vždy hodnotu nula, protože energii neobsahuje robot, ale samotná baterie. Pro zjištění stavu baterie robota musíte napsat <code>energyCell.energyLevel</code>. "
 
 #. type: Source code
-#: ../E/object.txt:40
+#: ../E/object.txt:39
 #, no-wrap
 msgid "<code>shieldLevel</code>"
 msgstr "<code>shieldLevel</code>"
 
 #. type: Plain text
-#: ../E/object.txt:41
+#: ../E/object.txt:40
 #, no-wrap
 msgid ""
 "Shield level of a robot or building. A level <code>1</code> indicates that the shield is still perfect. Every time that the bot or building gets a bullet or collides with another object, the shield level decreases. When the level reaches <code>0</code>, the next bullet or collision will destroy the bot or building. \n"
@@ -2478,49 +2494,49 @@ msgstr ""
 "Roboti si mohou doplnit štít v <a object|repair>opravně</a>. Budovu lze opravit tím, že ji obklopíte silovým polem <a object|botshld>mobilního štítu</a>."
 
 #. type: Source code
-#: ../E/object.txt:44
+#: ../E/object.txt:43
 #, no-wrap
 msgid "<code>temperature</code>"
 msgstr "<code>temperature</code>"
 
 #. type: Plain text
-#: ../E/object.txt:45
+#: ../E/object.txt:44
 #, no-wrap
 msgid "Temperature of the jet of <a object|botgj>winged bots</a>. <code>0</code> corresponds to a cold jet. When used, the temperature increases progressively. When it reaches the value <code>1</code>, the jet is overheated and stops working, until it cooled down a little. "
 msgstr "Teplota tryskového motoru <a object|botgj>létajícího robota</a>. Hodnota <code>0</code> znamená, že tryskový motor je studený. Během letu teplota průběžně roste. Když dosáhne hodnoty <code>1</code>, tryskový motor se přehřeje a přestane fungovat, dokud opět trochu nevychladne. "
 
 #. type: Source code
-#: ../E/object.txt:47
+#: ../E/object.txt:46
 #, no-wrap
 msgid "<code>altitude</code>"
 msgstr "<code>altitude</code>"
 
 #. type: Plain text
-#: ../E/object.txt:48
+#: ../E/object.txt:47
 #, no-wrap
 msgid "The <code>z</code> coordinate of the position indicates the altitude above sea level, whereas the <code>altitude</code> indicates the height above ground. This value is meaningful only for <a object|botgj>winged bots</a> and for <a object|wasp>wasps</a>. For all other objects, this value is zero. "
 msgstr "Souřadnice <code>z</code> polohy objektu udává nadmořskou výšku, zatímco atribut <code>altitude</code> udává výšku nad zemí. Tento atribut má smysl pouze u <a object|botgj>létajících robotů</a> a <a object|wasp>vos</a>. Všechny ostatní objekty zde mají hodnotu nula. "
 
 #. type: Source code
-#: ../E/object.txt:50
+#: ../E/object.txt:49
 #, no-wrap
 msgid "<code>lifeTime</code>"
 msgstr "<code>lifeTime</code>"
 
 #. type: Plain text
-#: ../E/object.txt:51
+#: ../E/object.txt:50
 #, no-wrap
 msgid "The age of the object in seconds since it's creation."
 msgstr "Stáří objektu v sekundách od jeho vytvoření."
 
 #. type: Source code
-#: ../E/object.txt:53
+#: ../E/object.txt:52
 #, no-wrap
 msgid "<code>energyCell</code>"
 msgstr "<code>energyCell</code>"
 
 #. type: Plain text
-#: ../E/object.txt:54
+#: ../E/object.txt:53
 #, no-wrap
 msgid ""
 "This information is special, because it returns the information about another object, in this case the power pack. This means that energyCell contains all the characteristics of a normal object, for example <code>category</code> (PowerCell or NuclearCell), <code>position</code> (the position of the cell), etc.\n"
@@ -2532,31 +2548,31 @@ msgstr ""
 "Pokud robot nemá žádnou baterii, <code>energyCell</code> obsahuje hodnotu <code>null</code>."
 
 #. type: Source code
-#: ../E/object.txt:58
+#: ../E/object.txt:57
 #, no-wrap
 msgid "<code>load</code>"
 msgstr "<code>load</code>"
 
 #. type: Plain text
-#: ../E/object.txt:59
+#: ../E/object.txt:58
 #, no-wrap
 msgid "This information also returns the description of a whole object: the description of the object carried by a <a object|botgr>grabber</a>. If it carries nothing, <code>load</code> returns <code>null</code>."
 msgstr "Tento atribut také obsahuje popis jiného objektu: informace o předmětu, který <a object|botgr>robotické rameno</a> drží v drapáku. Pokud nedrží nic, atribut <code>load</code> obsahuje hodnotu <code>null</code>."
 
 #. type: \t; header, \b; header
-#: ../E/expr.txt:100 ../E/expr.txt:124 ../E/expr.txt:146 ../E/expr.txt:171 ../E/expr.txt:188 ../E/factory.txt:21 ../E/object.txt:70
+#: ../E/expr.txt:99 ../E/expr.txt:123 ../E/expr.txt:145 ../E/expr.txt:170 ../E/expr.txt:187 ../E/factory.txt:21 ../E/object.txt:66
 #, no-wrap
 msgid "Examples"
 msgstr "Příklady"
 
 #. type: Plain text
-#: ../E/object.txt:71
+#: ../E/object.txt:67
 #, no-wrap
 msgid "The type <code>object</code> returns the special value <code><a cbot|null>null</a></code> when the object does not exist. For example:"
 msgstr "Proměnná typu <code>object</code> může obsahovat speciální hodnotu <code>null</code>, která znamená, že proměnná neobsahuje popis žádného objektu. Například:"
 
 #. type: Source code
-#: ../E/object.txt:73
+#: ../E/object.txt:69
 #, no-wrap
 msgid ""
 "\tobject a;\n"
@@ -3188,7 +3204,7 @@ msgid "Returns the first object found that corresponds to the specified category
 msgstr "Vrátí první nalezený objekt z požadované kategorie v zadané oblasti. Pokud v dané oblasti žádný takový objekt není, vrátí hodnotu <code><a cbot|null>null</a></code>."
 
 #. type: \t; header
-#: ../E/expr.txt:132 ../E/radar.txt:68
+#: ../E/expr.txt:131 ../E/radar.txt:68
 #, no-wrap
 msgid "Remark"
 msgstr "Poznámky"
@@ -6482,37 +6498,71 @@ msgid "Use this type for variables that contain the characteristics of an object
 msgstr "Tento datový typ používejte pro proměnné, které mají obsahovat popis objektu, ať už to má být robot, budova, surovina, nepřítel apod. Zde je seznam všech atributů objektu: "
 
 #. type: Plain text
-#: ../E/object.txt:20
+#: ../E/object.txt:4
+#, no-wrap
+msgid ""
+"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
+"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
+"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
+"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
+"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
+"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
+"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
+"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
+"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
+"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
+"<code>object object.energyCell   </code>Power cell on the bot\n"
+"<code>object object.load         </code>Object carried by the bot\n"
+"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
+"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object"
+msgstr ""
+"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Kategorie</a> objektu\n"
+"<code><a cbot|point>point</a>  object.position     </code>Poloha objektu (x,y,z)\n"
+"<code><a cbot|float>float</a>  object.orientation  </code>Azimut objektu (0..360)\n"
+"<code><a cbot|float>float</a>  object.pitch        </code>Náklon objektu vpřed/vzad\n"
+"<code><a cbot|float>float</a>  object.roll         </code>Náklon objektu vpravo/vlevo\n"
+"<code><a cbot|float>float</a>  object.energyLevel  </code>Stav baterie (0..1)\n"
+"<code><a cbot|float>float</a>  object.shieldLevel  </code>Stav štítu (0..1)\n"
+"<code><a cbot|float>float</a>  object.temperature  </code>Teplota tryskového motoru (0..1)\n"
+"<code><a cbot|float>float</a>  object.altitude     </code>Výška nad zemí\n"
+"<code><a cbot|float>float</a>  object.lifeTime     </code>Stáří objektu\n"
+"<code>object object.energyCell   </code>Baterie ve zdířce robota\n"
+"<code>object object.load         </code>Náklad v drapáku robota\n"
+"<code><a cbot|int>int</a>    object.team         </code>Tým, do kterého objekt patří (viz <a battles>souboje programátorů</a>)\n"
+"<code><a cbot|point>point</a>  object.velocity     </code>Rychlost a směr pohybu objektu"
+
+#. type: Plain text
+#: ../E/object.txt:19
 #, no-wrap
 msgid "Also, some objects have additional methods (instructions). See them in <a cbot>the main list</a> in the <c/>\"Instructions specific for some objects\" section."
 msgstr "Některé objekty navíc mají i další metody (příkazy). Jejich seznam najdete v sekci \"Příkazy vyhrazené jen pro některé objekty\" v <a cbot>obsahu</a> nápovědy jazyka CBOT."
 
 #. type: Plain text
-#: ../E/object.txt:23
+#: ../E/object.txt:22
 #, no-wrap
 msgid "The <n/><a cbot|category>category</a> of an object allows you to know what it is, f. ex. what kind of bot, building, enemy, etc."
 msgstr "<a cbot|category>Kategorie</a> objektu říká, co je to za objekt, např. jaký je to druh robota, budovy, nepřítele, apod."
 
 #. type: Source code
-#: ../E/object.txt:61
+#: ../E/object.txt:60
 #, no-wrap
 msgid "<code>team</code>"
 msgstr "<code>team</code>"
 
 #. type: Plain text
-#: ../E/object.txt:62
+#: ../E/object.txt:61
 #, no-wrap
 msgid "The bot's team. Used in <a battles>code battles</a>. If the object has no team assigned (e.g. in no team-based levels, the object being a resource), this is equal to <code>0</code>."
 msgstr "Tým, do kterého robot patří. Používá se v <a battles>soubojích programátorů</a>. Pokud objekt nepatří do žádného týmu (např. v misi bez týmů nebo když je objekt surovinou), bude zde hodnota <code>0</code>."
 
 #. type: Source code
-#: ../E/object.txt:64
+#: ../E/object.txt:63
 #, no-wrap
 msgid "<code>velocity</code>"
 msgstr "<code>velocity</code>"
 
 #. type: Plain text
-#: ../E/object.txt:65
+#: ../E/object.txt:64
 #, no-wrap
 msgid "Current velocity of the object. Should be treated as a three-dimensional vector."
 msgstr "Aktuální rychlost a směr pohybu objektu. Hodnota je vyjádřena jako trojrozměrný pohybový vektor."
@@ -7512,10 +7562,26 @@ msgid "Binary operators below are working with fundamental number types (<code><
 msgstr "Binární operátory uvedené níže pracují se základními číselnými typy (<code><a cbot|int>int</a></code>, <code><a cbot|float>float</a></code>)."
 
 #. type: \t; header
-#: ../E/expr.txt:53 ../E/expr.txt:90 ../E/expr.txt:116 ../E/expr.txt:141 ../E/expr.txt:164
+#: ../E/expr.txt:53 ../E/expr.txt:89 ../E/expr.txt:115 ../E/expr.txt:140 ../E/expr.txt:163
 #, no-wrap
 msgid "List"
 msgstr "Seznam"
+
+#. type: Plain text
+#: ../E/expr.txt:54
+#, no-wrap
+msgid ""
+"<code>+</code>  addition\n"
+"<code>-</code>  subtraction\n"
+"<code>*</code>  multiplication\n"
+"<code>/</code>  division\n"
+"<code>%</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
+msgstr ""
+"<code>+</code>  sčítání\n"
+"<code>-</code>  odčítání\n"
+"<code>*</code>  násobení\n"
+"<code>/</code>  dělení\n"
+"<code>%</code>  zbytek po dělení (pouze pro typ <code><a cbot|int>int</a></code>)"
 
 #. type: \t; header
 #: ../E/expr.txt:60
@@ -7542,49 +7608,49 @@ msgid "Real life examples"
 msgstr "Reálné příklady"
 
 #. type: \t; header
-#: ../E/expr.txt:82
+#: ../E/expr.txt:81
 #, no-wrap
 msgid "Compound assignment operators"
 msgstr "Složené operátory přiřazení"
 
 #. type: Plain text
-#: ../E/expr.txt:83
+#: ../E/expr.txt:82
 #, no-wrap
 msgid "Besides the <code>=</code> operator for variable assignment there are several compound-assignment operators."
 msgstr "Kromě operátoru <code>=</code> pro přiřazení do proměnné existuje i několik složených operátorů přiřazení."
 
 #. type: Plain text
-#: ../E/expr.txt:85
+#: ../E/expr.txt:84
 #, no-wrap
 msgid "The compound-assignment operators combine the <code>=</code> assignment operator with another binary operator such as <code>+</code> or <code>-</code>. Compound-assignment operators perform the operation specified by the additional operator and then assign the result to the left operand. For example, a compound-assignment expression such as"
 msgstr "Složené operátory přiřazení kombinují operátor přiřazení <code>=</code> s dalším binárním operátorem, například <code>+</code> nebo <code>-</code>. Složené operátory přiřazení provedou operaci určenou přidaným operátorem, a pak přiřadí výsledek do levého operandu. Například složený přiřazovací výraz"
 
 #. type: Source code
-#: ../E/expr.txt:86
+#: ../E/expr.txt:85
 #, no-wrap
 msgid "<code>lvalue += expression</code>"
 msgstr "<code>lhodnota += výraz</code>"
 
 #. type: Source code
-#: ../E/expr.txt:88
+#: ../E/expr.txt:87
 #, no-wrap
 msgid "<code>lvalue = lvalue + expression</code>"
 msgstr "<code>lhodnota = lhodnota + výraz</code>"
 
 #. type: \b; header
-#: ../E/expr.txt:97
+#: ../E/expr.txt:96
 #, no-wrap
 msgid "String concatenation"
 msgstr "Slučování řetězců"
 
 #. type: Plain text
-#: ../E/expr.txt:98
+#: ../E/expr.txt:97
 #, no-wrap
 msgid "If at least one of the values used with the <code>+</code> operator is a <a cbot|string>string</a>, then the operation of concatenation is performed. The result of the operator is then a string, which is created by joining end-to-end the string and the other value. If the other value is not a string, then it is converted to string beforehand."
 msgstr "Pokud je alespoň jeden operand operátoru <code>+</code> typu <a cbot|string>string</a>, provede se sloučení řetězců. Výsledkem operace je textový řetězec vytvoření přilepením pravého řetězce na konec levého. Pokud jeden z operandů není typu string, před provedením operace se automaticky zkonvertuje na textový řetězec."
 
 #. type: Source code
-#: ../E/expr.txt:102
+#: ../E/expr.txt:101
 #, no-wrap
 msgid ""
 "\tstring s = \"a\" + \"bc\";  // returns \"abc\"\n"
@@ -7598,43 +7664,43 @@ msgstr ""
 "\tstring s = \"a\" + true;  // vrátí \"atrue\""
 
 #. type: Plain text
-#: ../E/expr.txt:107
+#: ../E/expr.txt:106
 #, no-wrap
 msgid "Tip: the properties of the concatenation <code>+</code> operator is useful with the <a cbot|message>message();</a> function, because it does not work with other types than string. An empty string can be used together with a value in order to create a string, which actually can be passed to the <a cbot|message>message();</a> function:"
 msgstr "Tip: Vlastnosti operátoru sloučení řetězců <code>+</code> jsou zvláště užitečné pro funkci <a cbot|message>message();</a>, protože ta nepřijímá žádný jiný typ než string. Můžete například sloučit prázdný řetězec s jinou hodnotou, abyste z ní vytvořili textový řetězec, který pak můžete předat funkci <a cbot|message>message();</a>:"
 
 #. type: \b; header
-#: ../E/expr.txt:178
+#: ../E/expr.txt:177
 #, no-wrap
 msgid "Prefix and postfix increment- and decrement operators"
 msgstr "Unární operátory inkrementace a dekrementace"
 
 #. type: Plain text
-#: ../E/expr.txt:181
+#: ../E/expr.txt:180
 #, no-wrap
 msgid "For example to increment the variable <code>a</code> you can write"
 msgstr "Například pro zvýšení hodnoty proměnné <code>x</code> o 1 můžete napsat"
 
 #. type: Source code
-#: ../E/expr.txt:182
+#: ../E/expr.txt:181
 #, no-wrap
 msgid "<c/>a++;<n/>"
 msgstr "<c/>x++;<n/>"
 
 #. type: Plain text
-#: ../E/expr.txt:183
+#: ../E/expr.txt:182
 #, no-wrap
 msgid "instead of"
 msgstr "místo"
 
 #. type: Source code
-#: ../E/expr.txt:184
+#: ../E/expr.txt:183
 #, no-wrap
 msgid "<c/>a = a + 1;<n/>"
 msgstr "<c/>x = x + 1;<n/>"
 
 #. type: Plain text
-#: ../E/expr.txt:186
+#: ../E/expr.txt:185
 #, no-wrap
 msgid "The result of the operation <code>a++</code> is the value of the variable <code>a</code> *before* the increment. If you use the prefix operator <code>++a</code> the result of the operation is the value of the variable <code>a</code> *after* the increment. The same holds for the <code>--</code> decrement operator."
 msgstr "Výraz <code>x++</code> vrací hodnotu proměnné <code>x</code> *před* zvýšením. Pokud použijete prefixový operátor <code>++x</code>, výraz vrátí hodnotu proměnné <code>x</code> *po* zvýšení. Totéž platí pro operátor dekrementace <code>--</code>."
@@ -7658,7 +7724,41 @@ msgid "Note: it may be not obvious at first, but notice that <code>=</code> is a
 msgstr "Poznámka: Možná to na první pohled není zřejmé, ale všimněte si, že <code>=</code> je *operátor*, ne příkaz. To znamená, že ho můžete použít uvnitř jiného výrazu! Operátor <code>=</code> vrací hodnotu, která byla přiřazena do l-hodnoty - výsledek výrazu na pravé straně. Příklad:"
 
 #. type: Source code
-#: ../E/expr.txt:109
+#: ../E/expr.txt:66
+#, no-wrap
+msgid ""
+" int    i = 12 + 3;      // i == 15\n"
+" int    i = 2 - 5;       // i == -3\n"
+" \n"
+" float  f = 3.01 * 10;   // f == 30.1\n"
+" \n"
+" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
+" float  f = 5 / 3;       // f == 1.67\n"
+" float  f = 5 / 0;       // returns an error (division by zero)\n"
+" \n"
+" int    i = 13 % 5;      // i == 3\n"
+" int    i = -8 % 3;      // i == -2\n"
+" \n"
+" float  f = sin(90) * i; // f == -2.0\n"
+" "
+msgstr ""
+" int    i = 12 + 3;      // i == 15\n"
+" int    i = 2 - 5;       // i == -3\n"
+" \n"
+" float  f = 3.01 * 10;   // f == 30.1\n"
+" \n"
+" int    i = 5 / 3;       // i == 1 (automatická konverze na int)\n"
+" float  f = 5 / 3;       // f == 1.67\n"
+" float  f = 5 / 0;       // způsobí chybu (dělení nulou)\n"
+" \n"
+" int    i = 13 % 5;      // i == 3\n"
+" int    i = -8 % 3;      // i == -2\n"
+" \n"
+" float  f = sin(90) * i; // f == -2.0\n"
+" "
+
+#. type: Source code
+#: ../E/expr.txt:108
 #, no-wrap
 msgid ""
 " float pi = 3.14;\n"
@@ -7670,7 +7770,7 @@ msgstr ""
 " message(\"\"+pi);"
 
 #. type: Source code
-#: ../E/expr.txt:190
+#: ../E/expr.txt:189
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -7682,7 +7782,7 @@ msgstr ""
 " // y teď obsahuje 2, x obsahuje 3"
 
 #. type: Source code
-#: ../E/expr.txt:194
+#: ../E/expr.txt:193
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -7694,25 +7794,25 @@ msgstr ""
 " // y teď obsahuje 3, x obsahuje 3"
 
 #. type: \b; header
-#: ../E/expr.txt:138
+#: ../E/expr.txt:137
 #, no-wrap
 msgid "Logical operators"
 msgstr "Logické operátory"
 
 #. type: Plain text
-#: ../E/expr.txt:139
+#: ../E/expr.txt:138
 #, no-wrap
 msgid "Logical operators work with values of type <a cbot|bool>bool</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr "Logické operátory pracují s hodnotami typu <a cbot|bool>bool</a> a vždy vracejí hodnotu typu <a cbot|bool>bool</a>. Používají se především v <a cbot|cond>podmínkách</a>."
 
 #. type: \b; header
-#: ../E/expr.txt:151
+#: ../E/expr.txt:150
 #, no-wrap
 msgid "Ternary operator"
 msgstr "Ternární operátor"
 
 #. type: Plain text
-#: ../E/expr.txt:152
+#: ../E/expr.txt:151
 #, no-wrap
 msgid ""
 "The ternary operator is nothing more than a syntax sugar. It is also known as \"inline if\". It might be confusing at first, because its syntax is a little more complicated than other operators. It can be described as follows:\n"
@@ -7724,19 +7824,19 @@ msgstr ""
 "Závorky nejsou nutné."
 
 #. type: Plain text
-#: ../E/expr.txt:156
+#: ../E/expr.txt:155
 #, no-wrap
 msgid "Firstly, the condition is valued and then the first result is returned if the condition is true, otherwise the second result is returned."
 msgstr "Nejprve se vyhodnotí podmínka. Pokud platí, vrátí se první výraz, jinak se vrátí druhý výraz."
 
 #. type: \t; header
-#: ../E/expr.txt:158 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
+#: ../E/expr.txt:157 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
 #, no-wrap
 msgid "Example"
 msgstr "Příklad"
 
 #. type: Source code
-#: ../E/expr.txt:159
+#: ../E/expr.txt:158
 #, no-wrap
 msgid "<c/>float c = ((3.0 > 2.0) ? 10.0 : -10.0); // c == 10.0<n/>"
 msgstr "<c/>float c = ((3.0 > 2.0) ? 10.0 : -10.0); // c == 10.0<n/>"
@@ -7748,19 +7848,19 @@ msgid "A condition is a special <a cbot|expr>expression</a> that returns a <a cb
 msgstr "Podmínka je <a cbot|expr>výraz</a>, který vrací <a cbot|bool>booleovskou</a> hodnotu, tedy buď <code><a cbot|true>true</a></code>, nebo <code><a cbot|false>false</a></code>. Pomocí podmínky můžete určit například jestli se mají zopakovat příkazy uvnitř cyklu <code><a cbot|while>while</a></code> nebo jestli se mají provést příkazy v bloku <code><a cbot|if>if</a></code>."
 
 #. type: \b; header
-#: ../E/expr.txt:113
+#: ../E/expr.txt:112
 #, no-wrap
 msgid "Comparison operators"
 msgstr "Operátory porovnání"
 
 #. type: Plain text
-#: ../E/expr.txt:114
+#: ../E/expr.txt:113
 #, no-wrap
 msgid "Comparison operators work with values of type <a cbot|bool>float</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr "Operátory porovnání pracují s hodnotami typu <a cbot|float>float</a> a vždy vracejí hodnotu typu <a cbot|bool>bool</a>. Používají se především v <a cbot|cond>podmínkách</a>."
 
 #. type: Plain text
-#: ../E/expr.txt:142
+#: ../E/expr.txt:141
 #, no-wrap
 msgid ""
 "<code>!a      </code>not <code>a</code>\n"
@@ -7772,7 +7872,7 @@ msgstr ""
 "<code>x || y  </code>musí platit alespoň jedno z <code>x</code> nebo <code>y</code>"
 
 #. type: Plain text
-#: ../E/expr.txt:147
+#: ../E/expr.txt:146
 #, no-wrap
 msgid ""
 "<code>!false        </code>returns true\n"
@@ -7784,19 +7884,19 @@ msgstr ""
 "<code>true || false </code>vrátí true"
 
 #. type: \b; header
-#: ../E/expr.txt:161
+#: ../E/expr.txt:160
 #, no-wrap
 msgid "Bitwise operators"
 msgstr "Bitové operátory"
 
 #. type: Plain text
-#: ../E/expr.txt:162
+#: ../E/expr.txt:161
 #, no-wrap
 msgid "Bitwise operators are similar to the logical operator, because they are operating on bits (which can be only 0 or 1, conditions can have a value only of false or true). So in theory, they should be working with basically any type of variable, because each value in the computer must be stored as a sequence of bits."
 msgstr "Bitové operátory jsou podobné logickým operátorům, protože pracují s jednotlivými bity (které mohou mít pouze hodnotu 0 nebo 1, podobně jako podmínky mohou mít pouze hodnotu false nebo true). Takže teoreticky by měly fungovat se všemi datovými typy, protože v počítači jsou všechny hodnoty uloženy jako posloupnost bitů."
 
 #. type: Plain text
-#: ../E/expr.txt:165
+#: ../E/expr.txt:164
 #, no-wrap
 msgid ""
 "<code>a & b  </code><code>a</code> AND <code>b</code>\n"
@@ -7812,7 +7912,7 @@ msgstr ""
 "<code>x << y  </code>posune bity <code>x</code> doleva o <code>y</code> míst"
 
 #. type: Plain text
-#: ../E/expr.txt:172
+#: ../E/expr.txt:171
 #, no-wrap
 msgid ""
 "<code>2 & 1         </code>returns 0\n"
@@ -9079,6 +9179,12 @@ msgid "Starts a construction of a bot of a given <a cbot|category>category</a> a
 msgstr "Zahájí výrobu robota dané <a cbot|category>kategorie</a> a po dokončení na něm spustí zadaný program."
 
 #. type: Plain text
+#: ../E/factory.txt:11
+#, no-wrap
+msgid "Program that will be run on the bot after factory finishes the construction. This can be either a <a cbot|public>public</a> <a cbot|function>function</a>, a <a cbot|file>filename</a> or raw code."
+msgstr "Program, který se na robotovi spustí po dokončení výroby. Může to být buď <a cbot|public>public</a> <a cbot|function>funkce</a>, <a cbot|file>název souboru</a>, nebo prostě kus kódu."
+
+#. type: Plain text
 #: ../E/factory.txt:14
 #, no-wrap
 msgid "<a object|factory>BotFactory</a>, nearest by default."
@@ -9438,120 +9544,3 @@ msgid ""
 "     factory(WheeledGrabber, \"program/say-foo.cbot\");\n"
 " }"
 msgstr ""
-
-#. type: Plain text
-#: ../E/expr.txt:54
-#, no-wrap
-msgid ""
-"<code>+</code>  addition\n"
-"<code>-</code>  subtraction\n"
-"<code>*</code>  multiplication\n"
-"<code>/</code>  division\n"
-"<code>%</code>  remainder of the division (works for <code><a cbot|int>int</a></code> as well as <code><a cbot|float>float</a></code>)"
-msgstr ""
-"<code>+</code>  sčítání\n"
-"<code>-</code>  odčítání\n"
-"<code>*</code>  násobení\n"
-"<code>/</code>  dělení\n"
-"<code>%</code>  zbytek po dělení (Pracuje pro <code><a cbot|int>int</a></code> stejně jako <code><a cbot|float>float</a></code>)"
-
-#. type: Source code
-#: ../E/expr.txt:66
-#, no-wrap
-msgid ""
-" int    i = 12 + 3;      // i == 15\n"
-" int    i = 2 - 5;       // i == -3\n"
-" \n"
-" float  f = 3.01 * 10;   // f == 30.1\n"
-" \n"
-" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
-" float  f = 5 / 3;       // f == 1.67\n"
-" float  f = 5 / 0;       // returns an error (division by zero)\n"
-" \n"
-" int    i = 13 % 5;      // i == 3\n"
-" int    i = -8 % 3;      // i == -2\n"
-" float  f = -4.5 % 2.75; // f == -1.75\n"
-" \n"
-" float  f = sin(90) * i; // f == -2.0\n"
-" "
-msgstr ""
-" int    i = 12 + 3;      // i == 15\n"
-" int    i = 2 - 5;       // i == -3\n"
-" \n"
-" float  f = 3.01 * 10;   // f == 30.1\n"
-" \n"
-" int    i = 5 / 3;       // i == 1 (automatická konverze na int)\n"
-" float  f = 5 / 3;       // f == 1.67\n"
-" float  f = 5 / 0;       // způsobí chybu (dělení nulou)\n"
-" \n"
-" int    i = 13 % 5;      // i == 3\n"
-" int    i = -8 % 3;      // i == -2\n"
-" float  f = -4.5 % 2.75; // f == -1.75\n"
-"\n"
-" \n"
-" float  f = sin(90) * i; // f == -2.0\n"
-" "
-
-#. type: Plain text
-#: ../E/expr.txt:91
-#, no-wrap
-msgid ""
-"<code>+=</code>  addition\n"
-"<code>-=</code>  subtraction\n"
-"<code>*=</code>  multiplication\n"
-"<code>/=</code>  division\n"
-"<code>%=</code>  remainder of the division"
-msgstr ""
-"<code>+=</code>  sčítání\n"
-"<code>-=</code>  odčítání\n"
-"<code>*=</code>  násobení\n"
-"<code>/=</code>  dělení\n"
-"<code>%=</code>  zbytek po dělení"
-
-#. type: Plain text
-#: ../E/object.txt:4
-#, no-wrap
-msgid ""
-"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
-"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
-"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
-"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
-"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
-"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
-"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
-"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
-"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
-"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
-"<code>object object.energyCell   </code>Power cell on the bot\n"
-"<code>object object.load         </code>Object carried by the bot\n"
-"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
-"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object\n"
-"<code><a cbot|bool>bool</a>   object.dead         </code>Is the object dead?"
-msgstr ""
-"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Kategorie</a> objektu\n"
-"<code><a cbot|point>point</a>  object.position     </code>Poloha objektu (x,y,z)\n"
-"<code><a cbot|float>float</a>  object.orientation  </code>Azimut objektu (0..360)\n"
-"<code><a cbot|float>float</a>  object.pitch        </code>Náklon objektu vpřed/vzad\n"
-"<code><a cbot|float>float</a>  object.roll         </code>Náklon objektu vpravo/vlevo\n"
-"<code><a cbot|float>float</a>  object.energyLevel  </code>Stav baterie (0..1)\n"
-"<code><a cbot|float>float</a>  object.shieldLevel  </code>Stav štítu (0..1)\n"
-"<code><a cbot|float>float</a>  object.temperature  </code>Teplota tryskového motoru (0..1)\n"
-"<code><a cbot|float>float</a>  object.altitude     </code>Výška nad zemí\n"
-"<code><a cbot|float>float</a>  object.lifeTime     </code>Stáří objektu\n"
-"<code>object object.energyCell   </code>Baterie ve zdířce robota\n"
-"<code>object object.load         </code>Náklad v drapáku robota\n"
-"<code><a cbot|int>int</a>    object.team         </code>Tým, do kterého objekt patří (viz <a battles>souboje programátorů</a>)\n"
-"<code><a cbot|point>point</a>  object.velocity     </code>Rychlost a směr pohybu objektu\n"
-"<code><a cbot|bool>bool</a>   object.dead         </code>Je objekt mrtvý?"
-
-#. type: Source code
-#: ../E/object.txt:67
-#, no-wrap
-msgid "<code>dead</code>"
-msgstr ""
-
-#. type: Plain text
-#: ../E/object.txt:68
-#, no-wrap
-msgid "True if the object was recently killed (while the death animation is playing). Note that accessing this property or any other property after the death animation finishes will cause an error that stops the program."
-msgstr "True, pokud byl objekt nedávno zabit (během přehrávání animace smrti). Všimněte si, že přístup k této nebo jakékoli jiné vlastnosti po dokončení animace smrti způsobí chybu, která zastaví program."

--- a/help/cbot/po/cs.po
+++ b/help/cbot/po/cs.po
@@ -9362,13 +9362,13 @@ msgstr ""
 #: ../E/factory.txt:11
 #, no-wrap
 msgid "Program that will be run on the bot after factory finishes the construction. This can be either a <a cbot|public>public</a> <a cbot|function>function</a>, a filename or raw code."
-msgstr ""
+msgstr "Program, který se na robotovi spustí po dokončení výroby. Může to být buď <a cbot|public>public</a> <a cbot|function>funkce</a>, název souboru, nebo prostě kus kódu."
 
 #. type: Plain text
 #: ../E/factory.txt:23
 #, no-wrap
 msgid "Raw code:"
-msgstr ""
+msgstr "Kus kódu:"
 
 #. type: Source code
 #: ../E/factory.txt:25
@@ -9379,12 +9379,16 @@ msgid ""
 "     factory(WheeledGrabber, \"extern void Say123() { message(123); }\");\n"
 " }"
 msgstr ""
+" extern void New()\n"
+" {\n"
+"     factory(WheeledGrabber, \"extern void Say123() { message(123); }\");\n"
+" }"
 
 #. type: Plain text
 #: ../E/factory.txt:31
 #, no-wrap
 msgid "Public function:"
-msgstr ""
+msgstr "Public funkce:"
 
 #. type: Source code
 #: ../E/factory.txt:33
@@ -9400,18 +9404,27 @@ msgid ""
 "     message(\"hello\");\n"
 " }"
 msgstr ""
+" extern void New()\n"
+" {\n"
+"     factory(WheeledGrabber, \"SayHello\");\n"
+" }\n"
+"\n"
+" public void SayHello()\n"
+" {\n"
+"     message(\"Ahoj\");\n"
+" }"
 
 #. type: Plain text
 #: ../E/factory.txt:44
 #, no-wrap
 msgid "File name:"
-msgstr ""
+msgstr "Název souboru:"
 
 #. type: Plain text
 #: ../E/factory.txt:46
 #, no-wrap
 msgid "Save this as say-foo.cbot. Note: make sure to check the \"Public\" checkbox when saving - this will cause say-foo.cbot to be inside the program/ folder."
-msgstr ""
+msgstr "Tento program uložte do souboru say-foo.cbot. Poznámka: Zkontrolujte si, že jste při ukládání zaškrtli volbu \"Veřejný\" - tím soubor say-foo.cbot uložíte do adresáře program/."
 
 #. type: Source code
 #: ../E/factory.txt:48
@@ -9422,12 +9435,16 @@ msgid ""
 "     message(\"Foo\");\n"
 " }"
 msgstr ""
+" extern void New()\n"
+" {\n"
+"     message(\"Foo\");\n"
+" }"
 
 #. type: Plain text
 #: ../E/factory.txt:54
 #, no-wrap
 msgid "Run factory like this:"
-msgstr ""
+msgstr "Příkaz factory() zavolejte takto:"
 
 #. type: Source code
 #: ../E/factory.txt:56
@@ -9438,6 +9455,10 @@ msgid ""
 "     factory(WheeledGrabber, \"program/say-foo.cbot\");\n"
 " }"
 msgstr ""
+" extern void New()\n"
+" {\n"
+"     factory(WheeledGrabber, \"program/say-foo.cbot\");\n"
+" }"
 
 #. type: Plain text
 #: ../E/expr.txt:54
@@ -9449,6 +9470,11 @@ msgid ""
 "<code>/</code>  division\n"
 "<code>%</code>  remainder of the division (works for <code><a cbot|int>int</a></code> as well as <code><a cbot|float>float</a></code>)"
 msgstr ""
+"<code>+</code>  sčítání\n"
+"<code>-</code>  odčítání\n"
+"<code>*</code>  násobení\n"
+"<code>/</code>  dělení\n"
+"<code>%</code>  zbytek po dělení (funguje pro typ <code><a cbot|int>int</a></code> i <code><a cbot|float>float</a></code>)"
 
 #. type: Source code
 #: ../E/expr.txt:66
@@ -9470,6 +9496,21 @@ msgid ""
 " float  f = sin(90) * i; // f == -2.0\n"
 " "
 msgstr ""
+" int    i = 12 + 3;      // i == 15\n"
+" int    i = 2 - 5;       // i == -3\n"
+" \n"
+" float  f = 3.01 * 10;   // f == 30.1\n"
+" \n"
+" int    i = 5 / 3;       // i == 1 (automatické přetypování na int)\n"
+" float  f = 5 / 3;       // f == 1.67\n"
+" float  f = 5 / 0;       // způsobí chybu (dělení nulou)\n"
+" \n"
+" int    i = 13 % 5;      // i == 3\n"
+" int    i = -8 % 3;      // i == -2\n"
+" float  f = -4.5 % 2.75; // f == -1.75\n"
+" \n"
+" float  f = sin(90) * i; // f == -2.0\n"
+" "
 
 #. type: Plain text
 #: ../E/expr.txt:91
@@ -9481,6 +9522,11 @@ msgid ""
 "<code>/=</code>  division\n"
 "<code>%=</code>  remainder of the division"
 msgstr ""
+"<code>+=</code>  sčítání\n"
+"<code>-=</code>  odčítání\n"
+"<code>*=</code>  násobení\n"
+"<code>/=</code>  dělení\n"
+"<code>%=</code>  zbytek po dělení"
 
 #. type: Plain text
 #: ../E/object.txt:4
@@ -9502,15 +9548,30 @@ msgid ""
 "<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object\n"
 "<code><a cbot|bool>bool</a>   object.dead         </code>Is the object dead?"
 msgstr ""
+"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Kategorie</a> objektu\n"
+"<code><a cbot|point>point</a>  object.position     </code>Poloha objektu (x,y,z)\n"
+"<code><a cbot|float>float</a>  object.orientation  </code>Azimut objektu (0..360)\n"
+"<code><a cbot|float>float</a>  object.pitch        </code>Náklon objektu vpřed/vzad\n"
+"<code><a cbot|float>float</a>  object.roll         </code>Náklon objektu vpravo/vlevo\n"
+"<code><a cbot|float>float</a>  object.energyLevel  </code>Stav baterie (0..1)\n"
+"<code><a cbot|float>float</a>  object.shieldLevel  </code>Stav štítu (0..1)\n"
+"<code><a cbot|float>float</a>  object.temperature  </code>Teplota tryskového motoru (0..1)\n"
+"<code><a cbot|float>float</a>  object.altitude     </code>Výška nad zemí\n"
+"<code><a cbot|float>float</a>  object.lifeTime     </code>Stáří objektu\n"
+"<code>object object.energyCell   </code>Baterie ve zdířce robota\n"
+"<code>object object.load         </code>Náklad v drapáku robota\n"
+"<code><a cbot|int>int</a>    object.team         </code>Tým, do kterého objekt patří (viz <a battles>souboje programátorů</a>)\n"
+"<code><a cbot|point>point</a>  object.velocity     </code>Rychlost a směr pohybu objektu\n"
+"<code><a cbot|bool>bool</a>   object.dead         </code>Je objekt zničený?"
 
 #. type: Source code
 #: ../E/object.txt:67
 #, no-wrap
 msgid "<code>dead</code>"
-msgstr ""
+msgstr "<code>dead</code>"
 
 #. type: Plain text
 #: ../E/object.txt:68
 #, no-wrap
 msgid "True if the object was recently killed (while the death animation is playing). Note that accessing this property or any other property after the death animation finishes will cause an error that stops the program."
-msgstr ""
+msgstr "Obsahuje hodnotu true, pokud byl objekt před okamžikem zničen (stále se přehrává animace zničení). Pozor, přístup k tomuto nebo kterémukoliv jinému atributu objektu po dokončení jeho animace zničení způsobí chybu a ukončí program."

--- a/help/cbot/po/cs.po
+++ b/help/cbot/po/cs.po
@@ -9362,13 +9362,13 @@ msgstr ""
 #: ../E/factory.txt:11
 #, no-wrap
 msgid "Program that will be run on the bot after factory finishes the construction. This can be either a <a cbot|public>public</a> <a cbot|function>function</a>, a filename or raw code."
-msgstr "Program, který bude spuštěn na robotovi poté, co továrna dokončí stavbu. Může se jednat o <a cbot|public>veřejnou</a> <a cbot|function>funkci</a>, název souboru nebo nezpracovaný kód."
+msgstr ""
 
 #. type: Plain text
 #: ../E/factory.txt:23
 #, no-wrap
 msgid "Raw code:"
-msgstr "Nezpracovaný kód:"
+msgstr ""
 
 #. type: Source code
 #: ../E/factory.txt:25
@@ -9384,7 +9384,7 @@ msgstr ""
 #: ../E/factory.txt:31
 #, no-wrap
 msgid "Public function:"
-msgstr "Veřejnou funkci:"
+msgstr ""
 
 #. type: Source code
 #: ../E/factory.txt:33
@@ -9405,13 +9405,13 @@ msgstr ""
 #: ../E/factory.txt:44
 #, no-wrap
 msgid "File name:"
-msgstr "Název souboru:"
+msgstr ""
 
 #. type: Plain text
 #: ../E/factory.txt:46
 #, no-wrap
 msgid "Save this as say-foo.cbot. Note: make sure to check the \"Public\" checkbox when saving - this will cause say-foo.cbot to be inside the program/ folder."
-msgstr "Uložte to jako say-foo.cbot. Poznámka: při ukládání nezapomeňte zaškrtnout políčko \"Veřejný\" - to způsobí, že say-foo.cbot bude uvnitř program/ složky."
+msgstr ""
 
 #. type: Source code
 #: ../E/factory.txt:48
@@ -9427,7 +9427,7 @@ msgstr ""
 #: ../E/factory.txt:54
 #, no-wrap
 msgid "Run factory like this:"
-msgstr "Použijte factory funkci takto:"
+msgstr ""
 
 #. type: Source code
 #: ../E/factory.txt:56

--- a/help/cbot/po/cs.po
+++ b/help/cbot/po/cs.po
@@ -54,13 +54,13 @@ msgid "Time in seconds."
 msgstr "Čas v sekundách."
 
 #. type: \t; header
-#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:197 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:79 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
+#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:198 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:83 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
 #, no-wrap
 msgid "See also"
 msgstr "Užitečné odkazy"
 
 #. type: Plain text
-#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:198 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:80 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
+#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:199 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:84 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
 #, no-wrap
 msgid "<a cbot>Programming</a>, <a cbot|type>types</a> and <a cbot|category>categories</a>."
 msgstr "<a cbot>Programování</a>, <a cbot|type>datové typy</a> a <a cbot|category>kategorie</a>."
@@ -614,7 +614,7 @@ msgid "Conditions"
 msgstr "Podmínky"
 
 #. type: Plain text
-#: ../E/expr.txt:116
+#: ../E/expr.txt:117
 #, no-wrap
 msgid ""
 "<code>a == b  </code><code>a</code> equals <code>b</code>\n"
@@ -632,7 +632,7 @@ msgstr ""
 "<code>x >= y  </code><code>x</code> je větší nebo rovno <code>y</code>"
 
 #. type: Plain text
-#: ../E/expr.txt:124
+#: ../E/expr.txt:125
 #, no-wrap
 msgid ""
 "<code>12 == 12  </code>returns true\n"
@@ -650,13 +650,13 @@ msgstr ""
 "<code>12 >= 12  </code>vrátí true "
 
 #. type: Plain text
-#: ../E/expr.txt:132
+#: ../E/expr.txt:133
 #, no-wrap
 msgid "Be careful not to confuse the equality comparison <code>==</code> with the assignment of a <a cbot|var>variable</a> <code>=</code>."
 msgstr "Dávejte pozor, abyste si nespletli porovnání na rovnost <code>==</code> s přířazením do <a cbot|var>proměnné</a> <code>=</code>."
 
 #. type: Plain text
-#: ../E/expr.txt:134
+#: ../E/expr.txt:135
 #, no-wrap
 msgid ""
 "<code>a == b</code> is an expression that compares <code>a</code> with <code>b</code>.\n"
@@ -1256,29 +1256,13 @@ msgid "Expressions"
 msgstr "Výrazy"
 
 #. type: Plain text
-#: ../E/expr.txt:86
+#: ../E/expr.txt:87
 #, no-wrap
 msgid "is equivalent to"
 msgstr "dělá totéž jako"
 
 #. type: Plain text
-#: ../E/expr.txt:90
-#, no-wrap
-msgid ""
-"<code>+=</code>  addition\n"
-"<code>-=</code>  subtraction\n"
-"<code>*=</code>  multiplication\n"
-"<code>/=</code>  division\n"
-"<code>%=</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
-msgstr ""
-"<code>+=</code>  sčítání\n"
-"<code>-=</code>  odčítání\n"
-"<code>*=</code>  násobení\n"
-"<code>/=</code>  dělení\n"
-"<code>%=</code>  zbytek po dělení (pouze pro datový typ <code><a cbot|int>int</a></code>)"
-
-#. type: Plain text
-#: ../E/expr.txt:178
+#: ../E/expr.txt:179
 #, no-wrap
 msgid "The operators <code>++</code> and <code>--</code> allow you to increment (++) or to decrement (--) a variable in very compact and efficient manner."
 msgstr "Operátory <code>++</code> a <code>--</code> Vám umožňují stručně a jednoduše hodnotu proměnné zvýšit (++) nebo snížit (--) o jedničku."
@@ -2412,79 +2396,79 @@ msgid "Type <code>object</code>"
 msgstr "Datový typ <code>object</code>"
 
 #. type: Source code
-#: ../E/object.txt:21
+#: ../E/object.txt:22
 #, no-wrap
 msgid "<code>category</code>"
 msgstr "<code>category</code>"
 
 #. type: Source code
-#: ../E/object.txt:24
+#: ../E/object.txt:25
 #, no-wrap
 msgid "<code>position</code>"
 msgstr "<code>position</code>"
 
 #. type: Plain text
-#: ../E/object.txt:25
+#: ../E/object.txt:26
 #, no-wrap
 msgid "Position of the object on the planet, in meters. The coordinates <code>x</code> and <code>y</code> correspond to the location on a map, the <code>z</code> coordinate corresponds to the altitude above (respectively below) sea level. "
 msgstr "Poloha objektu na planetě, v metrech. Souřadnice <code>x</code> a <code>y</code> představují polohu na mapě, souřadnice <code>z</code> představuje nadmořskou výšku. "
 
 #. type: Source code
-#: ../E/object.txt:27
+#: ../E/object.txt:28
 #, no-wrap
 msgid "<code>orientation</code>"
 msgstr "<code>orientation</code>"
 
 #. type: Plain text
-#: ../E/object.txt:28
+#: ../E/object.txt:29
 #, no-wrap
 msgid "Orientation of the object, in degrees. The orientation tells you what direction the object is facing. An orientation of <code>0</code> corresponds to an object facing eastwards, thus following the positive <code>x</code> axis. The orientation is measured counterclockwise. "
 msgstr "Azimut objektu ve stupních. Tento atribut určuje, kterým směrem je objekt otočený. Azimut <code>0</code> znamená, že objekt směřuje na východ, tedy souběžně s kladnou poloosou <code>x</code>. Azimut se měří proti směru hodinových ručiček. "
 
 #. type: Source code
-#: ../E/object.txt:30
+#: ../E/object.txt:31
 #, no-wrap
 msgid "<code>pitch</code>"
 msgstr "<code>pitch</code>"
 
 #. type: Plain text
-#: ../E/object.txt:31
+#: ../E/object.txt:32
 #, no-wrap
 msgid "Forward/backward angle of the robot. A pitch of <code>0</code> means that the bot is standing on flat ground. A positive inclination means that it is facing upwards, a negative inclination means that it is facing downwards. "
 msgstr "Náklon objektu vpřed nebo vzad. Hodnota <code>0</code> znamená, že objekt se nachází ve vodorovné poloze. Kladná hodnota znamená náklon vzad (objekt míří čelem k nebi), záporná hodnota znamená náklon vpřed (objekt míří čelem do země). "
 
 #. type: Source code
-#: ../E/object.txt:33
+#: ../E/object.txt:34
 #, no-wrap
 msgid "<code>roll</code>"
 msgstr "<code>roll</code>"
 
 #. type: Plain text
-#: ../E/object.txt:34
+#: ../E/object.txt:35
 #, no-wrap
 msgid "Left/right angle of the bot, in degrees. A positive value means that the bot is leaning to the left side, a negative value means that it is leaning to the right side. "
 msgstr "Svislý náklon objektu vlevo nebo vpravo ve stupních. Kladná hodnota znamená, že objekt se naklání doleva, záporná hodnota znamená, že se naklání doprava. "
 
 #. type: Source code
-#: ../E/object.txt:36
+#: ../E/object.txt:37
 #, no-wrap
 msgid "<code>energyLevel</code>"
 msgstr "<code>energyLevel</code>"
 
 #. type: Plain text
-#: ../E/object.txt:37
+#: ../E/object.txt:38
 #, no-wrap
 msgid "Energy level, between 0 and 1. A normal <a object|power>power cell</a> that is fully charged returns the value <code>1</code>. A <a object|atomic>nuclear power cell</a> never returns a value higher than 1, it just lasts longer. Attention: The energy level of a bot is always zero, because the energy is not contained in the bot, but in the power cell. To know the energy level of the power cell of a bot, you must write <code>energyCell.energyLevel</code>. "
 msgstr "Stav baterie v rozsahu 0 až 1. Běžná plně nabitá <a object|power>baterie</a> zde bude mít hodnotu <code>1</code>. <a object|atomic>Jaderná baterie</a> zde také bude mít hodnotu nejvýše 1, ale vydrží mnohem déle. Pozor: robot zde bude mít vždy hodnotu nula, protože energii neobsahuje robot, ale samotná baterie. Pro zjištění stavu baterie robota musíte napsat <code>energyCell.energyLevel</code>. "
 
 #. type: Source code
-#: ../E/object.txt:39
+#: ../E/object.txt:40
 #, no-wrap
 msgid "<code>shieldLevel</code>"
 msgstr "<code>shieldLevel</code>"
 
 #. type: Plain text
-#: ../E/object.txt:40
+#: ../E/object.txt:41
 #, no-wrap
 msgid ""
 "Shield level of a robot or building. A level <code>1</code> indicates that the shield is still perfect. Every time that the bot or building gets a bullet or collides with another object, the shield level decreases. When the level reaches <code>0</code>, the next bullet or collision will destroy the bot or building. \n"
@@ -2494,49 +2478,49 @@ msgstr ""
 "Roboti si mohou doplnit štít v <a object|repair>opravně</a>. Budovu lze opravit tím, že ji obklopíte silovým polem <a object|botshld>mobilního štítu</a>."
 
 #. type: Source code
-#: ../E/object.txt:43
+#: ../E/object.txt:44
 #, no-wrap
 msgid "<code>temperature</code>"
 msgstr "<code>temperature</code>"
 
 #. type: Plain text
-#: ../E/object.txt:44
+#: ../E/object.txt:45
 #, no-wrap
 msgid "Temperature of the jet of <a object|botgj>winged bots</a>. <code>0</code> corresponds to a cold jet. When used, the temperature increases progressively. When it reaches the value <code>1</code>, the jet is overheated and stops working, until it cooled down a little. "
 msgstr "Teplota tryskového motoru <a object|botgj>létajícího robota</a>. Hodnota <code>0</code> znamená, že tryskový motor je studený. Během letu teplota průběžně roste. Když dosáhne hodnoty <code>1</code>, tryskový motor se přehřeje a přestane fungovat, dokud opět trochu nevychladne. "
 
 #. type: Source code
-#: ../E/object.txt:46
+#: ../E/object.txt:47
 #, no-wrap
 msgid "<code>altitude</code>"
 msgstr "<code>altitude</code>"
 
 #. type: Plain text
-#: ../E/object.txt:47
+#: ../E/object.txt:48
 #, no-wrap
 msgid "The <code>z</code> coordinate of the position indicates the altitude above sea level, whereas the <code>altitude</code> indicates the height above ground. This value is meaningful only for <a object|botgj>winged bots</a> and for <a object|wasp>wasps</a>. For all other objects, this value is zero. "
 msgstr "Souřadnice <code>z</code> polohy objektu udává nadmořskou výšku, zatímco atribut <code>altitude</code> udává výšku nad zemí. Tento atribut má smysl pouze u <a object|botgj>létajících robotů</a> a <a object|wasp>vos</a>. Všechny ostatní objekty zde mají hodnotu nula. "
 
 #. type: Source code
-#: ../E/object.txt:49
+#: ../E/object.txt:50
 #, no-wrap
 msgid "<code>lifeTime</code>"
 msgstr "<code>lifeTime</code>"
 
 #. type: Plain text
-#: ../E/object.txt:50
+#: ../E/object.txt:51
 #, no-wrap
 msgid "The age of the object in seconds since it's creation."
 msgstr "Stáří objektu v sekundách od jeho vytvoření."
 
 #. type: Source code
-#: ../E/object.txt:52
+#: ../E/object.txt:53
 #, no-wrap
 msgid "<code>energyCell</code>"
 msgstr "<code>energyCell</code>"
 
 #. type: Plain text
-#: ../E/object.txt:53
+#: ../E/object.txt:54
 #, no-wrap
 msgid ""
 "This information is special, because it returns the information about another object, in this case the power pack. This means that energyCell contains all the characteristics of a normal object, for example <code>category</code> (PowerCell or NuclearCell), <code>position</code> (the position of the cell), etc.\n"
@@ -2548,31 +2532,31 @@ msgstr ""
 "Pokud robot nemá žádnou baterii, <code>energyCell</code> obsahuje hodnotu <code>null</code>."
 
 #. type: Source code
-#: ../E/object.txt:57
+#: ../E/object.txt:58
 #, no-wrap
 msgid "<code>load</code>"
 msgstr "<code>load</code>"
 
 #. type: Plain text
-#: ../E/object.txt:58
+#: ../E/object.txt:59
 #, no-wrap
 msgid "This information also returns the description of a whole object: the description of the object carried by a <a object|botgr>grabber</a>. If it carries nothing, <code>load</code> returns <code>null</code>."
 msgstr "Tento atribut také obsahuje popis jiného objektu: informace o předmětu, který <a object|botgr>robotické rameno</a> drží v drapáku. Pokud nedrží nic, atribut <code>load</code> obsahuje hodnotu <code>null</code>."
 
 #. type: \t; header, \b; header
-#: ../E/expr.txt:99 ../E/expr.txt:123 ../E/expr.txt:145 ../E/expr.txt:170 ../E/expr.txt:187 ../E/factory.txt:21 ../E/object.txt:66
+#: ../E/expr.txt:100 ../E/expr.txt:124 ../E/expr.txt:146 ../E/expr.txt:171 ../E/expr.txt:188 ../E/factory.txt:21 ../E/object.txt:70
 #, no-wrap
 msgid "Examples"
 msgstr "Příklady"
 
 #. type: Plain text
-#: ../E/object.txt:67
+#: ../E/object.txt:71
 #, no-wrap
 msgid "The type <code>object</code> returns the special value <code><a cbot|null>null</a></code> when the object does not exist. For example:"
 msgstr "Proměnná typu <code>object</code> může obsahovat speciální hodnotu <code>null</code>, která znamená, že proměnná neobsahuje popis žádného objektu. Například:"
 
 #. type: Source code
-#: ../E/object.txt:69
+#: ../E/object.txt:73
 #, no-wrap
 msgid ""
 "\tobject a;\n"
@@ -3204,7 +3188,7 @@ msgid "Returns the first object found that corresponds to the specified category
 msgstr "Vrátí první nalezený objekt z požadované kategorie v zadané oblasti. Pokud v dané oblasti žádný takový objekt není, vrátí hodnotu <code><a cbot|null>null</a></code>."
 
 #. type: \t; header
-#: ../E/expr.txt:131 ../E/radar.txt:68
+#: ../E/expr.txt:132 ../E/radar.txt:68
 #, no-wrap
 msgid "Remark"
 msgstr "Poznámky"
@@ -6498,71 +6482,37 @@ msgid "Use this type for variables that contain the characteristics of an object
 msgstr "Tento datový typ používejte pro proměnné, které mají obsahovat popis objektu, ať už to má být robot, budova, surovina, nepřítel apod. Zde je seznam všech atributů objektu: "
 
 #. type: Plain text
-#: ../E/object.txt:4
-#, no-wrap
-msgid ""
-"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
-"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
-"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
-"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
-"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
-"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
-"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
-"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
-"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
-"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
-"<code>object object.energyCell   </code>Power cell on the bot\n"
-"<code>object object.load         </code>Object carried by the bot\n"
-"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
-"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object"
-msgstr ""
-"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Kategorie</a> objektu\n"
-"<code><a cbot|point>point</a>  object.position     </code>Poloha objektu (x,y,z)\n"
-"<code><a cbot|float>float</a>  object.orientation  </code>Azimut objektu (0..360)\n"
-"<code><a cbot|float>float</a>  object.pitch        </code>Náklon objektu vpřed/vzad\n"
-"<code><a cbot|float>float</a>  object.roll         </code>Náklon objektu vpravo/vlevo\n"
-"<code><a cbot|float>float</a>  object.energyLevel  </code>Stav baterie (0..1)\n"
-"<code><a cbot|float>float</a>  object.shieldLevel  </code>Stav štítu (0..1)\n"
-"<code><a cbot|float>float</a>  object.temperature  </code>Teplota tryskového motoru (0..1)\n"
-"<code><a cbot|float>float</a>  object.altitude     </code>Výška nad zemí\n"
-"<code><a cbot|float>float</a>  object.lifeTime     </code>Stáří objektu\n"
-"<code>object object.energyCell   </code>Baterie ve zdířce robota\n"
-"<code>object object.load         </code>Náklad v drapáku robota\n"
-"<code><a cbot|int>int</a>    object.team         </code>Tým, do kterého objekt patří (viz <a battles>souboje programátorů</a>)\n"
-"<code><a cbot|point>point</a>  object.velocity     </code>Rychlost a směr pohybu objektu"
-
-#. type: Plain text
-#: ../E/object.txt:19
+#: ../E/object.txt:20
 #, no-wrap
 msgid "Also, some objects have additional methods (instructions). See them in <a cbot>the main list</a> in the <c/>\"Instructions specific for some objects\" section."
 msgstr "Některé objekty navíc mají i další metody (příkazy). Jejich seznam najdete v sekci \"Příkazy vyhrazené jen pro některé objekty\" v <a cbot>obsahu</a> nápovědy jazyka CBOT."
 
 #. type: Plain text
-#: ../E/object.txt:22
+#: ../E/object.txt:23
 #, no-wrap
 msgid "The <n/><a cbot|category>category</a> of an object allows you to know what it is, f. ex. what kind of bot, building, enemy, etc."
 msgstr "<a cbot|category>Kategorie</a> objektu říká, co je to za objekt, např. jaký je to druh robota, budovy, nepřítele, apod."
 
 #. type: Source code
-#: ../E/object.txt:60
+#: ../E/object.txt:61
 #, no-wrap
 msgid "<code>team</code>"
 msgstr "<code>team</code>"
 
 #. type: Plain text
-#: ../E/object.txt:61
+#: ../E/object.txt:62
 #, no-wrap
 msgid "The bot's team. Used in <a battles>code battles</a>. If the object has no team assigned (e.g. in no team-based levels, the object being a resource), this is equal to <code>0</code>."
 msgstr "Tým, do kterého robot patří. Používá se v <a battles>soubojích programátorů</a>. Pokud objekt nepatří do žádného týmu (např. v misi bez týmů nebo když je objekt surovinou), bude zde hodnota <code>0</code>."
 
 #. type: Source code
-#: ../E/object.txt:63
+#: ../E/object.txt:64
 #, no-wrap
 msgid "<code>velocity</code>"
 msgstr "<code>velocity</code>"
 
 #. type: Plain text
-#: ../E/object.txt:64
+#: ../E/object.txt:65
 #, no-wrap
 msgid "Current velocity of the object. Should be treated as a three-dimensional vector."
 msgstr "Aktuální rychlost a směr pohybu objektu. Hodnota je vyjádřena jako trojrozměrný pohybový vektor."
@@ -7562,26 +7512,10 @@ msgid "Binary operators below are working with fundamental number types (<code><
 msgstr "Binární operátory uvedené níže pracují se základními číselnými typy (<code><a cbot|int>int</a></code>, <code><a cbot|float>float</a></code>)."
 
 #. type: \t; header
-#: ../E/expr.txt:53 ../E/expr.txt:89 ../E/expr.txt:115 ../E/expr.txt:140 ../E/expr.txt:163
+#: ../E/expr.txt:53 ../E/expr.txt:90 ../E/expr.txt:116 ../E/expr.txt:141 ../E/expr.txt:164
 #, no-wrap
 msgid "List"
 msgstr "Seznam"
-
-#. type: Plain text
-#: ../E/expr.txt:54
-#, no-wrap
-msgid ""
-"<code>+</code>  addition\n"
-"<code>-</code>  subtraction\n"
-"<code>*</code>  multiplication\n"
-"<code>/</code>  division\n"
-"<code>%</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
-msgstr ""
-"<code>+</code>  sčítání\n"
-"<code>-</code>  odčítání\n"
-"<code>*</code>  násobení\n"
-"<code>/</code>  dělení\n"
-"<code>%</code>  zbytek po dělení (pouze pro typ <code><a cbot|int>int</a></code>)"
 
 #. type: \t; header
 #: ../E/expr.txt:60
@@ -7608,49 +7542,49 @@ msgid "Real life examples"
 msgstr "Reálné příklady"
 
 #. type: \t; header
-#: ../E/expr.txt:81
+#: ../E/expr.txt:82
 #, no-wrap
 msgid "Compound assignment operators"
 msgstr "Složené operátory přiřazení"
 
 #. type: Plain text
-#: ../E/expr.txt:82
+#: ../E/expr.txt:83
 #, no-wrap
 msgid "Besides the <code>=</code> operator for variable assignment there are several compound-assignment operators."
 msgstr "Kromě operátoru <code>=</code> pro přiřazení do proměnné existuje i několik složených operátorů přiřazení."
 
 #. type: Plain text
-#: ../E/expr.txt:84
+#: ../E/expr.txt:85
 #, no-wrap
 msgid "The compound-assignment operators combine the <code>=</code> assignment operator with another binary operator such as <code>+</code> or <code>-</code>. Compound-assignment operators perform the operation specified by the additional operator and then assign the result to the left operand. For example, a compound-assignment expression such as"
 msgstr "Složené operátory přiřazení kombinují operátor přiřazení <code>=</code> s dalším binárním operátorem, například <code>+</code> nebo <code>-</code>. Složené operátory přiřazení provedou operaci určenou přidaným operátorem, a pak přiřadí výsledek do levého operandu. Například složený přiřazovací výraz"
 
 #. type: Source code
-#: ../E/expr.txt:85
+#: ../E/expr.txt:86
 #, no-wrap
 msgid "<code>lvalue += expression</code>"
 msgstr "<code>lhodnota += výraz</code>"
 
 #. type: Source code
-#: ../E/expr.txt:87
+#: ../E/expr.txt:88
 #, no-wrap
 msgid "<code>lvalue = lvalue + expression</code>"
 msgstr "<code>lhodnota = lhodnota + výraz</code>"
 
 #. type: \b; header
-#: ../E/expr.txt:96
+#: ../E/expr.txt:97
 #, no-wrap
 msgid "String concatenation"
 msgstr "Slučování řetězců"
 
 #. type: Plain text
-#: ../E/expr.txt:97
+#: ../E/expr.txt:98
 #, no-wrap
 msgid "If at least one of the values used with the <code>+</code> operator is a <a cbot|string>string</a>, then the operation of concatenation is performed. The result of the operator is then a string, which is created by joining end-to-end the string and the other value. If the other value is not a string, then it is converted to string beforehand."
 msgstr "Pokud je alespoň jeden operand operátoru <code>+</code> typu <a cbot|string>string</a>, provede se sloučení řetězců. Výsledkem operace je textový řetězec vytvoření přilepením pravého řetězce na konec levého. Pokud jeden z operandů není typu string, před provedením operace se automaticky zkonvertuje na textový řetězec."
 
 #. type: Source code
-#: ../E/expr.txt:101
+#: ../E/expr.txt:102
 #, no-wrap
 msgid ""
 "\tstring s = \"a\" + \"bc\";  // returns \"abc\"\n"
@@ -7664,43 +7598,43 @@ msgstr ""
 "\tstring s = \"a\" + true;  // vrátí \"atrue\""
 
 #. type: Plain text
-#: ../E/expr.txt:106
+#: ../E/expr.txt:107
 #, no-wrap
 msgid "Tip: the properties of the concatenation <code>+</code> operator is useful with the <a cbot|message>message();</a> function, because it does not work with other types than string. An empty string can be used together with a value in order to create a string, which actually can be passed to the <a cbot|message>message();</a> function:"
 msgstr "Tip: Vlastnosti operátoru sloučení řetězců <code>+</code> jsou zvláště užitečné pro funkci <a cbot|message>message();</a>, protože ta nepřijímá žádný jiný typ než string. Můžete například sloučit prázdný řetězec s jinou hodnotou, abyste z ní vytvořili textový řetězec, který pak můžete předat funkci <a cbot|message>message();</a>:"
 
 #. type: \b; header
-#: ../E/expr.txt:177
+#: ../E/expr.txt:178
 #, no-wrap
 msgid "Prefix and postfix increment- and decrement operators"
 msgstr "Unární operátory inkrementace a dekrementace"
 
 #. type: Plain text
-#: ../E/expr.txt:180
+#: ../E/expr.txt:181
 #, no-wrap
 msgid "For example to increment the variable <code>a</code> you can write"
 msgstr "Například pro zvýšení hodnoty proměnné <code>x</code> o 1 můžete napsat"
 
 #. type: Source code
-#: ../E/expr.txt:181
+#: ../E/expr.txt:182
 #, no-wrap
 msgid "<c/>a++;<n/>"
 msgstr "<c/>x++;<n/>"
 
 #. type: Plain text
-#: ../E/expr.txt:182
+#: ../E/expr.txt:183
 #, no-wrap
 msgid "instead of"
 msgstr "místo"
 
 #. type: Source code
-#: ../E/expr.txt:183
+#: ../E/expr.txt:184
 #, no-wrap
 msgid "<c/>a = a + 1;<n/>"
 msgstr "<c/>x = x + 1;<n/>"
 
 #. type: Plain text
-#: ../E/expr.txt:185
+#: ../E/expr.txt:186
 #, no-wrap
 msgid "The result of the operation <code>a++</code> is the value of the variable <code>a</code> *before* the increment. If you use the prefix operator <code>++a</code> the result of the operation is the value of the variable <code>a</code> *after* the increment. The same holds for the <code>--</code> decrement operator."
 msgstr "Výraz <code>x++</code> vrací hodnotu proměnné <code>x</code> *před* zvýšením. Pokud použijete prefixový operátor <code>++x</code>, výraz vrátí hodnotu proměnné <code>x</code> *po* zvýšení. Totéž platí pro operátor dekrementace <code>--</code>."
@@ -7724,41 +7658,7 @@ msgid "Note: it may be not obvious at first, but notice that <code>=</code> is a
 msgstr "Poznámka: Možná to na první pohled není zřejmé, ale všimněte si, že <code>=</code> je *operátor*, ne příkaz. To znamená, že ho můžete použít uvnitř jiného výrazu! Operátor <code>=</code> vrací hodnotu, která byla přiřazena do l-hodnoty - výsledek výrazu na pravé straně. Příklad:"
 
 #. type: Source code
-#: ../E/expr.txt:66
-#, no-wrap
-msgid ""
-" int    i = 12 + 3;      // i == 15\n"
-" int    i = 2 - 5;       // i == -3\n"
-" \n"
-" float  f = 3.01 * 10;   // f == 30.1\n"
-" \n"
-" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
-" float  f = 5 / 3;       // f == 1.67\n"
-" float  f = 5 / 0;       // returns an error (division by zero)\n"
-" \n"
-" int    i = 13 % 5;      // i == 3\n"
-" int    i = -8 % 3;      // i == -2\n"
-" \n"
-" float  f = sin(90) * i; // f == -2.0\n"
-" "
-msgstr ""
-" int    i = 12 + 3;      // i == 15\n"
-" int    i = 2 - 5;       // i == -3\n"
-" \n"
-" float  f = 3.01 * 10;   // f == 30.1\n"
-" \n"
-" int    i = 5 / 3;       // i == 1 (automatická konverze na int)\n"
-" float  f = 5 / 3;       // f == 1.67\n"
-" float  f = 5 / 0;       // způsobí chybu (dělení nulou)\n"
-" \n"
-" int    i = 13 % 5;      // i == 3\n"
-" int    i = -8 % 3;      // i == -2\n"
-" \n"
-" float  f = sin(90) * i; // f == -2.0\n"
-" "
-
-#. type: Source code
-#: ../E/expr.txt:108
+#: ../E/expr.txt:109
 #, no-wrap
 msgid ""
 " float pi = 3.14;\n"
@@ -7770,7 +7670,7 @@ msgstr ""
 " message(\"\"+pi);"
 
 #. type: Source code
-#: ../E/expr.txt:189
+#: ../E/expr.txt:190
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -7782,7 +7682,7 @@ msgstr ""
 " // y teď obsahuje 2, x obsahuje 3"
 
 #. type: Source code
-#: ../E/expr.txt:193
+#: ../E/expr.txt:194
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -7794,25 +7694,25 @@ msgstr ""
 " // y teď obsahuje 3, x obsahuje 3"
 
 #. type: \b; header
-#: ../E/expr.txt:137
+#: ../E/expr.txt:138
 #, no-wrap
 msgid "Logical operators"
 msgstr "Logické operátory"
 
 #. type: Plain text
-#: ../E/expr.txt:138
+#: ../E/expr.txt:139
 #, no-wrap
 msgid "Logical operators work with values of type <a cbot|bool>bool</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr "Logické operátory pracují s hodnotami typu <a cbot|bool>bool</a> a vždy vracejí hodnotu typu <a cbot|bool>bool</a>. Používají se především v <a cbot|cond>podmínkách</a>."
 
 #. type: \b; header
-#: ../E/expr.txt:150
+#: ../E/expr.txt:151
 #, no-wrap
 msgid "Ternary operator"
 msgstr "Ternární operátor"
 
 #. type: Plain text
-#: ../E/expr.txt:151
+#: ../E/expr.txt:152
 #, no-wrap
 msgid ""
 "The ternary operator is nothing more than a syntax sugar. It is also known as \"inline if\". It might be confusing at first, because its syntax is a little more complicated than other operators. It can be described as follows:\n"
@@ -7824,19 +7724,19 @@ msgstr ""
 "Závorky nejsou nutné."
 
 #. type: Plain text
-#: ../E/expr.txt:155
+#: ../E/expr.txt:156
 #, no-wrap
 msgid "Firstly, the condition is valued and then the first result is returned if the condition is true, otherwise the second result is returned."
 msgstr "Nejprve se vyhodnotí podmínka. Pokud platí, vrátí se první výraz, jinak se vrátí druhý výraz."
 
 #. type: \t; header
-#: ../E/expr.txt:157 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
+#: ../E/expr.txt:158 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
 #, no-wrap
 msgid "Example"
 msgstr "Příklad"
 
 #. type: Source code
-#: ../E/expr.txt:158
+#: ../E/expr.txt:159
 #, no-wrap
 msgid "<c/>float c = ((3.0 > 2.0) ? 10.0 : -10.0); // c == 10.0<n/>"
 msgstr "<c/>float c = ((3.0 > 2.0) ? 10.0 : -10.0); // c == 10.0<n/>"
@@ -7848,19 +7748,19 @@ msgid "A condition is a special <a cbot|expr>expression</a> that returns a <a cb
 msgstr "Podmínka je <a cbot|expr>výraz</a>, který vrací <a cbot|bool>booleovskou</a> hodnotu, tedy buď <code><a cbot|true>true</a></code>, nebo <code><a cbot|false>false</a></code>. Pomocí podmínky můžete určit například jestli se mají zopakovat příkazy uvnitř cyklu <code><a cbot|while>while</a></code> nebo jestli se mají provést příkazy v bloku <code><a cbot|if>if</a></code>."
 
 #. type: \b; header
-#: ../E/expr.txt:112
+#: ../E/expr.txt:113
 #, no-wrap
 msgid "Comparison operators"
 msgstr "Operátory porovnání"
 
 #. type: Plain text
-#: ../E/expr.txt:113
+#: ../E/expr.txt:114
 #, no-wrap
 msgid "Comparison operators work with values of type <a cbot|bool>float</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr "Operátory porovnání pracují s hodnotami typu <a cbot|float>float</a> a vždy vracejí hodnotu typu <a cbot|bool>bool</a>. Používají se především v <a cbot|cond>podmínkách</a>."
 
 #. type: Plain text
-#: ../E/expr.txt:141
+#: ../E/expr.txt:142
 #, no-wrap
 msgid ""
 "<code>!a      </code>not <code>a</code>\n"
@@ -7872,7 +7772,7 @@ msgstr ""
 "<code>x || y  </code>musí platit alespoň jedno z <code>x</code> nebo <code>y</code>"
 
 #. type: Plain text
-#: ../E/expr.txt:146
+#: ../E/expr.txt:147
 #, no-wrap
 msgid ""
 "<code>!false        </code>returns true\n"
@@ -7884,19 +7784,19 @@ msgstr ""
 "<code>true || false </code>vrátí true"
 
 #. type: \b; header
-#: ../E/expr.txt:160
+#: ../E/expr.txt:161
 #, no-wrap
 msgid "Bitwise operators"
 msgstr "Bitové operátory"
 
 #. type: Plain text
-#: ../E/expr.txt:161
+#: ../E/expr.txt:162
 #, no-wrap
 msgid "Bitwise operators are similar to the logical operator, because they are operating on bits (which can be only 0 or 1, conditions can have a value only of false or true). So in theory, they should be working with basically any type of variable, because each value in the computer must be stored as a sequence of bits."
 msgstr "Bitové operátory jsou podobné logickým operátorům, protože pracují s jednotlivými bity (které mohou mít pouze hodnotu 0 nebo 1, podobně jako podmínky mohou mít pouze hodnotu false nebo true). Takže teoreticky by měly fungovat se všemi datovými typy, protože v počítači jsou všechny hodnoty uloženy jako posloupnost bitů."
 
 #. type: Plain text
-#: ../E/expr.txt:164
+#: ../E/expr.txt:165
 #, no-wrap
 msgid ""
 "<code>a & b  </code><code>a</code> AND <code>b</code>\n"
@@ -7912,7 +7812,7 @@ msgstr ""
 "<code>x << y  </code>posune bity <code>x</code> doleva o <code>y</code> míst"
 
 #. type: Plain text
-#: ../E/expr.txt:171
+#: ../E/expr.txt:172
 #, no-wrap
 msgid ""
 "<code>2 & 1         </code>returns 0\n"
@@ -9179,12 +9079,6 @@ msgid "Starts a construction of a bot of a given <a cbot|category>category</a> a
 msgstr "Zahájí výrobu robota dané <a cbot|category>kategorie</a> a po dokončení na něm spustí zadaný program."
 
 #. type: Plain text
-#: ../E/factory.txt:11
-#, no-wrap
-msgid "Program that will be run on the bot after factory finishes the construction. This can be either a <a cbot|public>public</a> <a cbot|function>function</a>, a <a cbot|file>filename</a> or raw code."
-msgstr "Program, který se na robotovi spustí po dokončení výroby. Může to být buď <a cbot|public>public</a> <a cbot|function>funkce</a>, <a cbot|file>název souboru</a>, nebo prostě kus kódu."
-
-#. type: Plain text
 #: ../E/factory.txt:14
 #, no-wrap
 msgid "<a object|factory>BotFactory</a>, nearest by default."
@@ -9543,4 +9437,80 @@ msgid ""
 " {\n"
 "     factory(WheeledGrabber, \"program/say-foo.cbot\");\n"
 " }"
+msgstr ""
+
+#. type: Plain text
+#: ../E/expr.txt:54
+#, no-wrap
+msgid ""
+"<code>+</code>  addition\n"
+"<code>-</code>  subtraction\n"
+"<code>*</code>  multiplication\n"
+"<code>/</code>  division\n"
+"<code>%</code>  remainder of the division (works for <code><a cbot|int>int</a></code> as well as <code><a cbot|float>float</a></code>)"
+msgstr ""
+
+#. type: Source code
+#: ../E/expr.txt:66
+#, no-wrap
+msgid ""
+" int    i = 12 + 3;      // i == 15\n"
+" int    i = 2 - 5;       // i == -3\n"
+" \n"
+" float  f = 3.01 * 10;   // f == 30.1\n"
+" \n"
+" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
+" float  f = 5 / 3;       // f == 1.67\n"
+" float  f = 5 / 0;       // returns an error (division by zero)\n"
+" \n"
+" int    i = 13 % 5;      // i == 3\n"
+" int    i = -8 % 3;      // i == -2\n"
+" float  f = -4.5 % 2.75; // f == -1.75\n"
+" \n"
+" float  f = sin(90) * i; // f == -2.0\n"
+" "
+msgstr ""
+
+#. type: Plain text
+#: ../E/expr.txt:91
+#, no-wrap
+msgid ""
+"<code>+=</code>  addition\n"
+"<code>-=</code>  subtraction\n"
+"<code>*=</code>  multiplication\n"
+"<code>/=</code>  division\n"
+"<code>%=</code>  remainder of the division"
+msgstr ""
+
+#. type: Plain text
+#: ../E/object.txt:4
+#, no-wrap
+msgid ""
+"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
+"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
+"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
+"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
+"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
+"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
+"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
+"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
+"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
+"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
+"<code>object object.energyCell   </code>Power cell on the bot\n"
+"<code>object object.load         </code>Object carried by the bot\n"
+"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
+"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object\n"
+"<code><a cbot|bool>bool</a>   object.dead         </code>Is the object dead?"
+msgstr ""
+
+#. type: Source code
+#: ../E/object.txt:67
+#, no-wrap
+msgid "<code>dead</code>"
+msgstr ""
+
+#. type: Plain text
+#: ../E/object.txt:68
+#, no-wrap
+msgid "True if the object was recently killed (while the death animation is playing). Note that accessing this property or any other property after the death animation finishes will cause an error that stops the program."
 msgstr ""

--- a/help/cbot/po/de.po
+++ b/help/cbot/po/de.po
@@ -6014,19 +6014,19 @@ msgstr ""
 #: ../E/factory.txt:1
 #, no-wrap
 msgid "Instruction <code>factory</code>"
-msgstr "Anweisung <code>factory</code>"
+msgstr ""
 
 #. type: Plain text
 #: ../E/factory.txt:8
 #, no-wrap
 msgid "<a cbot|category>Category</a> of the robot to construct."
-msgstr "<a cbot|category>Kategorie</a> des zu konstruierenden Roboters."
+msgstr ""
 
 #. type: \t; header
 #: ../E/factory.txt:10
 #, no-wrap
 msgid "program: <code><a cbot|string>string</a></code> (default value: <code>\"\"</code>)"
-msgstr "program: <code><a cbot|string>string</a></code> (Standardwert: <code>\"\"</code>)"
+msgstr ""
 
 #. type: Plain text
 #: ../E/factory.txt:17
@@ -6036,9 +6036,6 @@ msgid ""
 "<code>== 0 </code>The construction successfully started\n"
 "<code>!= 0 </code>The construction could not be started (e.g. no <a object|titan>Titanium</a> in the factory, the bot is not researched)"
 msgstr ""
-"Normalerweise bewirkt ein Fehler, dass das Programm angehalten wird. Wenn Sie wollen, dass das Programm durch einen Fehler nicht angehalten wird, benutzen Sie den Befehl <code><a cbot|errmode>errmode</a>(0)</code>. In diesem Fall gibt der Befehl einen Wert verschieden von Null zurück, wenn beim Ausführen von <code>factory()</code> ein Fehler aufgetreten ist.\n"
-"<code>== 0 </code>Der Bau hat erfolgreich begonnen\n"
-"<code>!= 0 </code>Der Bau konnte nicht gestartet werden (z.B. kein <a object|titan>Titan</a> in der Fabrik, der Bot wird nicht erforscht)"
 
 #. type: \b; header
 #: ../E/flatspace.txt:1
@@ -8526,13 +8523,13 @@ msgstr ""
 #: ../E/factory.txt:5
 #, no-wrap
 msgid "Starts a construction of a bot of a given <a cbot|category>category</a> and runs a specified program on it after the construction is finished."
-msgstr "Startet die Konstruktion eines Bots einer bestimmten <a cbot|category>Kategorie</a> und führt ein angegebenes Programm darauf aus, nachdem die Konstruktion abgeschlossen ist."
+msgstr ""
 
 #. type: Plain text
 #: ../E/factory.txt:14
 #, no-wrap
 msgid "<a object|factory>BotFactory</a>, nearest by default."
-msgstr "<a object|factory>BotFactory</a>, standardmäßig am nächsten."
+msgstr ""
 
 #. type: Plain text
 #: ../E/factory.txt:62
@@ -8768,13 +8765,13 @@ msgstr ""
 #: ../E/factory.txt:11
 #, no-wrap
 msgid "Program that will be run on the bot after factory finishes the construction. This can be either a <a cbot|public>public</a> <a cbot|function>function</a>, a filename or raw code."
-msgstr "Programm, das auf dem Bot ausgeführt wird, nachdem die Fabrik die Konstruktion abgeschlossen hat. Dabei kann es sich entweder um eine <a cbot|public>öffentliche</a> <a cbot|function>Funktion</a>, einen Dateinamen oder einen Codeschnipsel handeln."
+msgstr ""
 
 #. type: Plain text
 #: ../E/factory.txt:23
 #, no-wrap
 msgid "Raw code:"
-msgstr "Codeschnipsel:"
+msgstr ""
 
 #. type: Source code
 #: ../E/factory.txt:25
@@ -8790,7 +8787,7 @@ msgstr ""
 #: ../E/factory.txt:31
 #, no-wrap
 msgid "Public function:"
-msgstr "Öffentliche Funktion:"
+msgstr ""
 
 #. type: Source code
 #: ../E/factory.txt:33
@@ -8811,13 +8808,13 @@ msgstr ""
 #: ../E/factory.txt:44
 #, no-wrap
 msgid "File name:"
-msgstr "Dateinamen:"
+msgstr ""
 
 #. type: Plain text
 #: ../E/factory.txt:46
 #, no-wrap
 msgid "Save this as say-foo.cbot. Note: make sure to check the \"Public\" checkbox when saving - this will cause say-foo.cbot to be inside the program/ folder."
-msgstr "Speichern Sie dies als say-foo.cbot. Hinweis: Stellen Sie sicher, dass Sie beim Speichern das Kontrollkästchen \"Öffentlich\" aktivieren - dies führt dazu, dass sich say-foo.cbot im program/-Ordner befindet."
+msgstr ""
 
 #. type: Source code
 #: ../E/factory.txt:48
@@ -8833,7 +8830,7 @@ msgstr ""
 #: ../E/factory.txt:54
 #, no-wrap
 msgid "Run factory like this:"
-msgstr "Verwenden Sie die Factory-Funktion wie folgt:"
+msgstr ""
 
 #. type: Source code
 #: ../E/factory.txt:56

--- a/help/cbot/po/de.po
+++ b/help/cbot/po/de.po
@@ -53,13 +53,13 @@ msgid "Time in seconds."
 msgstr "Zeit in Sekunden."
 
 #. type: \t; header
-#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:197 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:79 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
+#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:198 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:83 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
 #, no-wrap
 msgid "See also"
 msgstr "Siehe auch"
 
 #. type: Plain text
-#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:198 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:80 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
+#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:199 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:84 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
 #, no-wrap
 msgid "<a cbot>Programming</a>, <a cbot|type>types</a> and <a cbot|category>categories</a>."
 msgstr "Die <a cbot>CBOT-Sprache</a>, <a cbot|type>Variablentypen</a> und <a cbot|category>Kategorien</a>."
@@ -561,7 +561,7 @@ msgid "Conditions"
 msgstr "Die Bedingungen"
 
 #. type: Plain text
-#: ../E/expr.txt:116
+#: ../E/expr.txt:117
 #, no-wrap
 msgid ""
 "<code>a == b  </code><code>a</code> equals <code>b</code>\n"
@@ -579,7 +579,7 @@ msgstr ""
 "<code>a >= b  </code><code>a</code> größer oder gleich <code>b</code>"
 
 #. type: Plain text
-#: ../E/expr.txt:124
+#: ../E/expr.txt:125
 #, no-wrap
 msgid ""
 "<code>12 == 12  </code>returns true\n"
@@ -597,13 +597,13 @@ msgstr ""
 "<code>12 >= 12  </code>ergibt wahr "
 
 #. type: Plain text
-#: ../E/expr.txt:132
+#: ../E/expr.txt:133
 #, no-wrap
 msgid "Be careful not to confuse the equality comparison <code>==</code> with the assignment of a <a cbot|var>variable</a> <code>=</code>."
 msgstr "Bitte verwechseln Sie nicht den Gleich-Operator <code>==</code> mit der Zuweisung einer <a cbot|var>Variable</a> <code>=</code>."
 
 #. type: Plain text
-#: ../E/expr.txt:134
+#: ../E/expr.txt:135
 #, no-wrap
 msgid ""
 "<code>a == b</code> is an expression that compares <code>a</code> with <code>b</code>.\n"
@@ -1211,29 +1211,13 @@ msgid "Expressions"
 msgstr "Ausdrücke"
 
 #. type: Plain text
-#: ../E/expr.txt:86
+#: ../E/expr.txt:87
 #, no-wrap
 msgid "is equivalent to"
 msgstr "entspricht folgendem Ausdruck ohne Kurzform:"
 
 #. type: Plain text
-#: ../E/expr.txt:90
-#, no-wrap
-msgid ""
-"<code>+=</code>  addition\n"
-"<code>-=</code>  subtraction\n"
-"<code>*=</code>  multiplication\n"
-"<code>/=</code>  division\n"
-"<code>%=</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
-msgstr ""
-"<code>+=</code>  addieren\n"
-"<code>-=</code>  subtrahieren\n"
-"<code>*=</code>  multiplizieren\n"
-"<code>/=</code>  dividieren\n"
-"<code>%=</code>  Rest der Division (nur für den Typ <code><a cbot|int>int</a></code>)"
-
-#. type: Plain text
-#: ../E/expr.txt:178
+#: ../E/expr.txt:179
 #, no-wrap
 msgid "The operators <code>++</code> and <code>--</code> allow you to increment (++) or to decrement (--) a variable in very compact and efficient manner."
 msgstr "Mit den Operatore <code>++</code> und <code>--</code> können Sie eine Variable mit einer sehr kurzen Schreibform inkrementieren (1 addieren) bzw. dekrementieren (1 subtrahieren)."
@@ -2378,79 +2362,79 @@ msgid "Type <code>object</code>"
 msgstr "Typ <code>object</code>"
 
 #. type: Source code
-#: ../E/object.txt:21
+#: ../E/object.txt:22
 #, no-wrap
 msgid "<code>category</code>"
 msgstr "<code>category</code>"
 
 #. type: Source code
-#: ../E/object.txt:24
+#: ../E/object.txt:25
 #, no-wrap
 msgid "<code>position</code>"
 msgstr "<code>position</code>"
 
 #. type: Plain text
-#: ../E/object.txt:25
+#: ../E/object.txt:26
 #, no-wrap
 msgid "Position of the object on the planet, in meters. The coordinates <code>x</code> and <code>y</code> correspond to the location on a map, the <code>z</code> coordinate corresponds to the altitude above (respectively below) sea level. "
 msgstr "Position des Objekts auf dem Planeten, in Meter. Die <code>x-</code> und <code>y-</code>Koordinaten entsprechen der Position auf der Karte, die <code>z-</code>Koordinate entspricht der Höhe über (bzw. unter) Meeresspiegel. "
 
 #. type: Source code
-#: ../E/object.txt:27
+#: ../E/object.txt:28
 #, no-wrap
 msgid "<code>orientation</code>"
 msgstr "<code>orientation</code>"
 
 #. type: Plain text
-#: ../E/object.txt:28
+#: ../E/object.txt:29
 #, no-wrap
 msgid "Orientation of the object, in degrees. The orientation tells you what direction the object is facing. An orientation of <code>0</code> corresponds to an object facing eastwards, thus following the positive <code>x</code> axis. The orientation is measured counterclockwise. "
 msgstr "Ausrichtung (Gierwinkel) des Objekts in Grad. Die Ausrichtung gibt an, wohin das Objekt schaut. Eine Ausrichtung <code>0</code> entspricht einem Objekt, das nach Osten schaut, also entlang der positiven <code>x-</code>Axe. Der Winkel wird im Gegenuhrzeigersinn gemessen. "
 
 #. type: Source code
-#: ../E/object.txt:30
+#: ../E/object.txt:31
 #, no-wrap
 msgid "<code>pitch</code>"
 msgstr "<code>pitch</code>"
 
 #. type: Plain text
-#: ../E/object.txt:31
+#: ../E/object.txt:32
 #, no-wrap
 msgid "Forward/backward angle of the robot. A pitch of <code>0</code> means that the bot is standing on flat ground. A positive inclination means that it is facing upwards, a negative inclination means that it is facing downwards. "
 msgstr "Nickwinkel (Drehung nach vorne/hinten) des Roboters. Ein Nickwinkel <code>0</code> bedeutet, das der Roboter auf ebener Erde steht. Ein positiver Nickwinkel bedeutet, dass er nach oben schaut, ein negativer nach unten. "
 
 #. type: Source code
-#: ../E/object.txt:33
+#: ../E/object.txt:34
 #, no-wrap
 msgid "<code>roll</code>"
 msgstr "<code>roll</code>"
 
 #. type: Plain text
-#: ../E/object.txt:34
+#: ../E/object.txt:35
 #, no-wrap
 msgid "Left/right angle of the bot, in degrees. A positive value means that the bot is leaning to the left side, a negative value means that it is leaning to the right side. "
 msgstr "Rollwinkel (Neigung nach rechts/links) des Roboters in Grad. Ein positiver Wert bedeutet eine Neigung auf die linke Seite, ein negativer Wert eine Neigung auf die rechte Seite. "
 
 #. type: Source code
-#: ../E/object.txt:36
+#: ../E/object.txt:37
 #, no-wrap
 msgid "<code>energyLevel</code>"
 msgstr "<code>energyLevel</code>"
 
 #. type: Plain text
-#: ../E/object.txt:37
+#: ../E/object.txt:38
 #, no-wrap
 msgid "Energy level, between 0 and 1. A normal <a object|power>power cell</a> that is fully charged returns the value <code>1</code>. A <a object|atomic>nuclear power cell</a> never returns a value higher than 1, it just lasts longer. Attention: The energy level of a bot is always zero, because the energy is not contained in the bot, but in the power cell. To know the energy level of the power cell of a bot, you must write <code>energyCell.energyLevel</code>. "
 msgstr "Energievorrat, zwischen 0 und 1. Eine normale voll geladene <a object|power>elektrolytische Batterie</a> gibt den Wert <code>1</code> zurück. Eine <a object|fuelcell>Brennstoffzelle</a> gibt trotz der größeren Kapazität auch nie einen Wert über <code>1</code> zurück, der Wert sinkt jedoch langsamer. Achtung: der Energievorrat eines Roboters ist immer Null, da die Energie nicht im Roboter, sondern in der Batterie enthalten ist. Um den Vorrat in der Batterie eines Roboters zu erhalten, schreiben Sie <code>energyCell.energyLevel</code>. "
 
 #. type: Source code
-#: ../E/object.txt:39
+#: ../E/object.txt:40
 #, no-wrap
 msgid "<code>shieldLevel</code>"
 msgstr "<code>shieldLevel</code>"
 
 #. type: Plain text
-#: ../E/object.txt:40
+#: ../E/object.txt:41
 #, no-wrap
 msgid ""
 "Shield level of a robot or building. A level <code>1</code> indicates that the shield is still perfect. Every time that the bot or building gets a bullet or collides with another object, the shield level decreases. When the level reaches <code>0</code>, the next bullet or collision will destroy the bot or building. \n"
@@ -2460,49 +2444,49 @@ msgstr ""
 "Roboter können ihren Schaden auf einem <a object|repair>Reparaturzentrum</a> ausbessern lassen. Schäden an Gebäuden und auch Robotern können ausgebessert werden, wenn sie innerhalb der Sphäre eines aktiven <a object|botshld>Schutzschildroboters</a> liegen."
 
 #. type: Source code
-#: ../E/object.txt:43
+#: ../E/object.txt:44
 #, no-wrap
 msgid "<code>temperature</code>"
 msgstr "<code>temperature</code>"
 
 #. type: Plain text
-#: ../E/object.txt:44
+#: ../E/object.txt:45
 #, no-wrap
 msgid "Temperature of the jet of <a object|botgj>winged bots</a>. <code>0</code> corresponds to a cold jet. When used, the temperature increases progressively. When it reaches the value <code>1</code>, the jet is overheated and stops working, until it cooled down a little. "
 msgstr "Triebwerktemperatur von <a object|botgj>Jetrobotern</a>. <code>0</code> entspricht einem kalten Triebwerk. Solange ein Triebwerk in Betrieb ist, steigt die Temperatur ständig. Wenn es den Wert <code>1</code> erreicht, ist es überhitzt und stellt den Betrieb ein, bis es abgekühlt ist."
 
 #. type: Source code
-#: ../E/object.txt:46
+#: ../E/object.txt:47
 #, no-wrap
 msgid "<code>altitude</code>"
 msgstr "<code>altitude</code>"
 
 #. type: Plain text
-#: ../E/object.txt:47
+#: ../E/object.txt:48
 #, no-wrap
 msgid "The <code>z</code> coordinate of the position indicates the altitude above sea level, whereas the <code>altitude</code> indicates the height above ground. This value is meaningful only for <a object|botgj>winged bots</a> and for <a object|wasp>wasps</a>. For all other objects, this value is zero. "
 msgstr "Die <code>z-</code>Koordinate gibt die Höhe über Meeresspiegel an, während <code>altitude</code> die Höhe über Grund angibt. Dieser Wert ist nützlich für <a object|botgj>Jetroboter</a> und für <a object|wasp>Wespen</a>. Für alle anderen Objekte beträgt der Wert Null. "
 
 #. type: Source code
-#: ../E/object.txt:49
+#: ../E/object.txt:50
 #, no-wrap
 msgid "<code>lifeTime</code>"
 msgstr "<code>lifeTime</code>"
 
 #. type: Plain text
-#: ../E/object.txt:50
+#: ../E/object.txt:51
 #, no-wrap
 msgid "The age of the object in seconds since it's creation."
 msgstr "Alter des Objekts in Sekunden seit seiner \"Geburt\"."
 
 #. type: Source code
-#: ../E/object.txt:52
+#: ../E/object.txt:53
 #, no-wrap
 msgid "<code>energyCell</code>"
 msgstr "<code>energyCell</code>"
 
 #. type: Plain text
-#: ../E/object.txt:53
+#: ../E/object.txt:54
 #, no-wrap
 msgid ""
 "This information is special, because it returns the information about another object, in this case the power pack. This means that energyCell contains all the characteristics of a normal object, for example <code>category</code> (PowerCell or NuclearCell), <code>position</code> (the position of the cell), etc.\n"
@@ -2514,31 +2498,31 @@ msgstr ""
 "Wenn der Roboter keine Batterie hat, gibt <code>energyCell</code> den Wert <code>null</code> zurück."
 
 #. type: Source code
-#: ../E/object.txt:57
+#: ../E/object.txt:58
 #, no-wrap
 msgid "<code>load</code>"
 msgstr "<code>load</code>"
 
 #. type: Plain text
-#: ../E/object.txt:58
+#: ../E/object.txt:59
 #, no-wrap
 msgid "This information also returns the description of a whole object: the description of the object carried by a <a object|botgr>grabber</a>. If it carries nothing, <code>load</code> returns <code>null</code>."
 msgstr "Diese Information gibt ebenfalls die Beschreibung eines ganzen Gegenstands zurück, in diesem Fall des Objekts, das ein <a object|botgr>Greifer</a> trägt. Wenn er nichts trägt, gibt <code>load</code> den Wert <code>null</code> zurück."
 
 #. type: \t; header, \b; header
-#: ../E/expr.txt:99 ../E/expr.txt:123 ../E/expr.txt:145 ../E/expr.txt:170 ../E/expr.txt:187 ../E/factory.txt:21 ../E/object.txt:66
+#: ../E/expr.txt:100 ../E/expr.txt:124 ../E/expr.txt:146 ../E/expr.txt:171 ../E/expr.txt:188 ../E/factory.txt:21 ../E/object.txt:70
 #, no-wrap
 msgid "Examples"
 msgstr "Beispiel"
 
 #. type: Plain text
-#: ../E/object.txt:67
+#: ../E/object.txt:71
 #, no-wrap
 msgid "The type <code>object</code> returns the special value <code><a cbot|null>null</a></code> when the object does not exist. For example:"
 msgstr "Der Typ <code>object</code> gibt den speziellen Wert <code><a cbot|null>null</a></code> zurück, wenn das Objekt nicht existiert, z.B.:"
 
 #. type: Source code
-#: ../E/object.txt:69
+#: ../E/object.txt:73
 #, no-wrap
 msgid ""
 "\tobject a;\n"
@@ -5452,7 +5436,7 @@ msgstr ""
 "\t<n/>Anweisung 3<c/>;"
 
 #. type: \t; header
-#: ../E/expr.txt:131 ../E/radar.txt:68
+#: ../E/expr.txt:132 ../E/radar.txt:68
 #, no-wrap
 msgid "Remark"
 msgstr "Bemerkung"
@@ -6371,57 +6355,37 @@ msgid "Use this type for variables that contain the characteristics of an object
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:4
-#, no-wrap
-msgid ""
-"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
-"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
-"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
-"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
-"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
-"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
-"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
-"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
-"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
-"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
-"<code>object object.energyCell   </code>Power cell on the bot\n"
-"<code>object object.load         </code>Object carried by the bot\n"
-"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
-"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object"
-msgstr ""
-
-#. type: Plain text
-#: ../E/object.txt:19
+#: ../E/object.txt:20
 #, no-wrap
 msgid "Also, some objects have additional methods (instructions). See them in <a cbot>the main list</a> in the <c/>\"Instructions specific for some objects\" section."
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:22
+#: ../E/object.txt:23
 #, no-wrap
 msgid "The <n/><a cbot|category>category</a> of an object allows you to know what it is, f. ex. what kind of bot, building, enemy, etc."
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:60
+#: ../E/object.txt:61
 #, no-wrap
 msgid "<code>team</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:61
+#: ../E/object.txt:62
 #, no-wrap
 msgid "The bot's team. Used in <a battles>code battles</a>. If the object has no team assigned (e.g. in no team-based levels, the object being a resource), this is equal to <code>0</code>."
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:63
+#: ../E/object.txt:64
 #, no-wrap
 msgid "<code>velocity</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:64
+#: ../E/object.txt:65
 #, no-wrap
 msgid "Current velocity of the object. Should be treated as a three-dimensional vector."
 msgstr ""
@@ -7332,20 +7296,9 @@ msgid "Binary operators below are working with fundamental number types (<code><
 msgstr ""
 
 #. type: \t; header
-#: ../E/expr.txt:53 ../E/expr.txt:89 ../E/expr.txt:115 ../E/expr.txt:140 ../E/expr.txt:163
+#: ../E/expr.txt:53 ../E/expr.txt:90 ../E/expr.txt:116 ../E/expr.txt:141 ../E/expr.txt:164
 #, no-wrap
 msgid "List"
-msgstr ""
-
-#. type: Plain text
-#: ../E/expr.txt:54
-#, no-wrap
-msgid ""
-"<code>+</code>  addition\n"
-"<code>-</code>  subtraction\n"
-"<code>*</code>  multiplication\n"
-"<code>/</code>  division\n"
-"<code>%</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
 msgstr ""
 
 #. type: \t; header
@@ -7373,49 +7326,49 @@ msgid "Real life examples"
 msgstr ""
 
 #. type: \t; header
-#: ../E/expr.txt:81
+#: ../E/expr.txt:82
 #, no-wrap
 msgid "Compound assignment operators"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:82
+#: ../E/expr.txt:83
 #, no-wrap
 msgid "Besides the <code>=</code> operator for variable assignment there are several compound-assignment operators."
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:84
+#: ../E/expr.txt:85
 #, no-wrap
 msgid "The compound-assignment operators combine the <code>=</code> assignment operator with another binary operator such as <code>+</code> or <code>-</code>. Compound-assignment operators perform the operation specified by the additional operator and then assign the result to the left operand. For example, a compound-assignment expression such as"
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:85
+#: ../E/expr.txt:86
 #, no-wrap
 msgid "<code>lvalue += expression</code>"
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:87
+#: ../E/expr.txt:88
 #, no-wrap
 msgid "<code>lvalue = lvalue + expression</code>"
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:96
+#: ../E/expr.txt:97
 #, no-wrap
 msgid "String concatenation"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:97
+#: ../E/expr.txt:98
 #, no-wrap
 msgid "If at least one of the values used with the <code>+</code> operator is a <a cbot|string>string</a>, then the operation of concatenation is performed. The result of the operator is then a string, which is created by joining end-to-end the string and the other value. If the other value is not a string, then it is converted to string beforehand."
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:101
+#: ../E/expr.txt:102
 #, no-wrap
 msgid ""
 "\tstring s = \"a\" + \"bc\";  // returns \"abc\"\n"
@@ -7425,43 +7378,43 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:106
+#: ../E/expr.txt:107
 #, no-wrap
 msgid "Tip: the properties of the concatenation <code>+</code> operator is useful with the <a cbot|message>message();</a> function, because it does not work with other types than string. An empty string can be used together with a value in order to create a string, which actually can be passed to the <a cbot|message>message();</a> function:"
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:177
+#: ../E/expr.txt:178
 #, no-wrap
 msgid "Prefix and postfix increment- and decrement operators"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:180
+#: ../E/expr.txt:181
 #, no-wrap
 msgid "For example to increment the variable <code>a</code> you can write"
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:181
+#: ../E/expr.txt:182
 #, no-wrap
 msgid "<c/>a++;<n/>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:182
+#: ../E/expr.txt:183
 #, no-wrap
 msgid "instead of"
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:183
+#: ../E/expr.txt:184
 #, no-wrap
 msgid "<c/>a = a + 1;<n/>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:185
+#: ../E/expr.txt:186
 #, no-wrap
 msgid "The result of the operation <code>a++</code> is the value of the variable <code>a</code> *before* the increment. If you use the prefix operator <code>++a</code> the result of the operation is the value of the variable <code>a</code> *after* the increment. The same holds for the <code>--</code> decrement operator."
 msgstr ""
@@ -7485,27 +7438,7 @@ msgid "Note: it may be not obvious at first, but notice that <code>=</code> is a
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:66
-#, no-wrap
-msgid ""
-" int    i = 12 + 3;      // i == 15\n"
-" int    i = 2 - 5;       // i == -3\n"
-" \n"
-" float  f = 3.01 * 10;   // f == 30.1\n"
-" \n"
-" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
-" float  f = 5 / 3;       // f == 1.67\n"
-" float  f = 5 / 0;       // returns an error (division by zero)\n"
-" \n"
-" int    i = 13 % 5;      // i == 3\n"
-" int    i = -8 % 3;      // i == -2\n"
-" \n"
-" float  f = sin(90) * i; // f == -2.0\n"
-" "
-msgstr ""
-
-#. type: Source code
-#: ../E/expr.txt:108
+#: ../E/expr.txt:109
 #, no-wrap
 msgid ""
 " float pi = 3.14;\n"
@@ -7514,7 +7447,7 @@ msgid ""
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:189
+#: ../E/expr.txt:190
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -7523,7 +7456,7 @@ msgid ""
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:193
+#: ../E/expr.txt:194
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -7532,25 +7465,25 @@ msgid ""
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:137
+#: ../E/expr.txt:138
 #, no-wrap
 msgid "Logical operators"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:138
+#: ../E/expr.txt:139
 #, no-wrap
 msgid "Logical operators work with values of type <a cbot|bool>bool</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:150
+#: ../E/expr.txt:151
 #, no-wrap
 msgid "Ternary operator"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:151
+#: ../E/expr.txt:152
 #, no-wrap
 msgid ""
 "The ternary operator is nothing more than a syntax sugar. It is also known as \"inline if\". It might be confusing at first, because its syntax is a little more complicated than other operators. It can be described as follows:\n"
@@ -7559,19 +7492,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:155
+#: ../E/expr.txt:156
 #, no-wrap
 msgid "Firstly, the condition is valued and then the first result is returned if the condition is true, otherwise the second result is returned."
 msgstr ""
 
 #. type: \t; header
-#: ../E/expr.txt:157 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
+#: ../E/expr.txt:158 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
 #, no-wrap
 msgid "Example"
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:158
+#: ../E/expr.txt:159
 #, no-wrap
 msgid "<c/>float c = ((3.0 > 2.0) ? 10.0 : -10.0); // c == 10.0<n/>"
 msgstr ""
@@ -7583,19 +7516,19 @@ msgid "A condition is a special <a cbot|expr>expression</a> that returns a <a cb
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:112
+#: ../E/expr.txt:113
 #, no-wrap
 msgid "Comparison operators"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:113
+#: ../E/expr.txt:114
 #, no-wrap
 msgid "Comparison operators work with values of type <a cbot|bool>float</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:141
+#: ../E/expr.txt:142
 #, no-wrap
 msgid ""
 "<code>!a      </code>not <code>a</code>\n"
@@ -7604,7 +7537,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:146
+#: ../E/expr.txt:147
 #, no-wrap
 msgid ""
 "<code>!false        </code>returns true\n"
@@ -7613,19 +7546,19 @@ msgid ""
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:160
+#: ../E/expr.txt:161
 #, no-wrap
 msgid "Bitwise operators"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:161
+#: ../E/expr.txt:162
 #, no-wrap
 msgid "Bitwise operators are similar to the logical operator, because they are operating on bits (which can be only 0 or 1, conditions can have a value only of false or true). So in theory, they should be working with basically any type of variable, because each value in the computer must be stored as a sequence of bits."
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:164
+#: ../E/expr.txt:165
 #, no-wrap
 msgid ""
 "<code>a & b  </code><code>a</code> AND <code>b</code>\n"
@@ -7636,7 +7569,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:171
+#: ../E/expr.txt:172
 #, no-wrap
 msgid ""
 "<code>2 & 1         </code>returns 0\n"
@@ -8907,4 +8840,80 @@ msgid ""
 " {\n"
 "     factory(WheeledGrabber, \"program/say-foo.cbot\");\n"
 " }"
+msgstr ""
+
+#. type: Plain text
+#: ../E/expr.txt:54
+#, no-wrap
+msgid ""
+"<code>+</code>  addition\n"
+"<code>-</code>  subtraction\n"
+"<code>*</code>  multiplication\n"
+"<code>/</code>  division\n"
+"<code>%</code>  remainder of the division (works for <code><a cbot|int>int</a></code> as well as <code><a cbot|float>float</a></code>)"
+msgstr ""
+
+#. type: Source code
+#: ../E/expr.txt:66
+#, no-wrap
+msgid ""
+" int    i = 12 + 3;      // i == 15\n"
+" int    i = 2 - 5;       // i == -3\n"
+" \n"
+" float  f = 3.01 * 10;   // f == 30.1\n"
+" \n"
+" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
+" float  f = 5 / 3;       // f == 1.67\n"
+" float  f = 5 / 0;       // returns an error (division by zero)\n"
+" \n"
+" int    i = 13 % 5;      // i == 3\n"
+" int    i = -8 % 3;      // i == -2\n"
+" float  f = -4.5 % 2.75; // f == -1.75\n"
+" \n"
+" float  f = sin(90) * i; // f == -2.0\n"
+" "
+msgstr ""
+
+#. type: Plain text
+#: ../E/expr.txt:91
+#, no-wrap
+msgid ""
+"<code>+=</code>  addition\n"
+"<code>-=</code>  subtraction\n"
+"<code>*=</code>  multiplication\n"
+"<code>/=</code>  division\n"
+"<code>%=</code>  remainder of the division"
+msgstr ""
+
+#. type: Plain text
+#: ../E/object.txt:4
+#, no-wrap
+msgid ""
+"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
+"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
+"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
+"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
+"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
+"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
+"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
+"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
+"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
+"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
+"<code>object object.energyCell   </code>Power cell on the bot\n"
+"<code>object object.load         </code>Object carried by the bot\n"
+"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
+"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object\n"
+"<code><a cbot|bool>bool</a>   object.dead         </code>Is the object dead?"
+msgstr ""
+
+#. type: Source code
+#: ../E/object.txt:67
+#, no-wrap
+msgid "<code>dead</code>"
+msgstr ""
+
+#. type: Plain text
+#: ../E/object.txt:68
+#, no-wrap
+msgid "True if the object was recently killed (while the death animation is playing). Note that accessing this property or any other property after the death animation finishes will cause an error that stops the program."
 msgstr ""

--- a/help/cbot/po/de.po
+++ b/help/cbot/po/de.po
@@ -53,13 +53,13 @@ msgid "Time in seconds."
 msgstr "Zeit in Sekunden."
 
 #. type: \t; header
-#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:198 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:83 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
+#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:197 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:79 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
 #, no-wrap
 msgid "See also"
 msgstr "Siehe auch"
 
 #. type: Plain text
-#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:199 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:84 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
+#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:198 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:80 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
 #, no-wrap
 msgid "<a cbot>Programming</a>, <a cbot|type>types</a> and <a cbot|category>categories</a>."
 msgstr "Die <a cbot>CBOT-Sprache</a>, <a cbot|type>Variablentypen</a> und <a cbot|category>Kategorien</a>."
@@ -561,7 +561,7 @@ msgid "Conditions"
 msgstr "Die Bedingungen"
 
 #. type: Plain text
-#: ../E/expr.txt:117
+#: ../E/expr.txt:116
 #, no-wrap
 msgid ""
 "<code>a == b  </code><code>a</code> equals <code>b</code>\n"
@@ -579,7 +579,7 @@ msgstr ""
 "<code>a >= b  </code><code>a</code> größer oder gleich <code>b</code>"
 
 #. type: Plain text
-#: ../E/expr.txt:125
+#: ../E/expr.txt:124
 #, no-wrap
 msgid ""
 "<code>12 == 12  </code>returns true\n"
@@ -597,13 +597,13 @@ msgstr ""
 "<code>12 >= 12  </code>ergibt wahr "
 
 #. type: Plain text
-#: ../E/expr.txt:133
+#: ../E/expr.txt:132
 #, no-wrap
 msgid "Be careful not to confuse the equality comparison <code>==</code> with the assignment of a <a cbot|var>variable</a> <code>=</code>."
 msgstr "Bitte verwechseln Sie nicht den Gleich-Operator <code>==</code> mit der Zuweisung einer <a cbot|var>Variable</a> <code>=</code>."
 
 #. type: Plain text
-#: ../E/expr.txt:135
+#: ../E/expr.txt:134
 #, no-wrap
 msgid ""
 "<code>a == b</code> is an expression that compares <code>a</code> with <code>b</code>.\n"
@@ -1211,13 +1211,29 @@ msgid "Expressions"
 msgstr "Ausdrücke"
 
 #. type: Plain text
-#: ../E/expr.txt:87
+#: ../E/expr.txt:86
 #, no-wrap
 msgid "is equivalent to"
 msgstr "entspricht folgendem Ausdruck ohne Kurzform:"
 
 #. type: Plain text
-#: ../E/expr.txt:179
+#: ../E/expr.txt:90
+#, no-wrap
+msgid ""
+"<code>+=</code>  addition\n"
+"<code>-=</code>  subtraction\n"
+"<code>*=</code>  multiplication\n"
+"<code>/=</code>  division\n"
+"<code>%=</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
+msgstr ""
+"<code>+=</code>  addieren\n"
+"<code>-=</code>  subtrahieren\n"
+"<code>*=</code>  multiplizieren\n"
+"<code>/=</code>  dividieren\n"
+"<code>%=</code>  Rest der Division (nur für den Typ <code><a cbot|int>int</a></code>)"
+
+#. type: Plain text
+#: ../E/expr.txt:178
 #, no-wrap
 msgid "The operators <code>++</code> and <code>--</code> allow you to increment (++) or to decrement (--) a variable in very compact and efficient manner."
 msgstr "Mit den Operatore <code>++</code> und <code>--</code> können Sie eine Variable mit einer sehr kurzen Schreibform inkrementieren (1 addieren) bzw. dekrementieren (1 subtrahieren)."
@@ -2362,79 +2378,79 @@ msgid "Type <code>object</code>"
 msgstr "Typ <code>object</code>"
 
 #. type: Source code
-#: ../E/object.txt:22
+#: ../E/object.txt:21
 #, no-wrap
 msgid "<code>category</code>"
 msgstr "<code>category</code>"
 
 #. type: Source code
-#: ../E/object.txt:25
+#: ../E/object.txt:24
 #, no-wrap
 msgid "<code>position</code>"
 msgstr "<code>position</code>"
 
 #. type: Plain text
-#: ../E/object.txt:26
+#: ../E/object.txt:25
 #, no-wrap
 msgid "Position of the object on the planet, in meters. The coordinates <code>x</code> and <code>y</code> correspond to the location on a map, the <code>z</code> coordinate corresponds to the altitude above (respectively below) sea level. "
 msgstr "Position des Objekts auf dem Planeten, in Meter. Die <code>x-</code> und <code>y-</code>Koordinaten entsprechen der Position auf der Karte, die <code>z-</code>Koordinate entspricht der Höhe über (bzw. unter) Meeresspiegel. "
 
 #. type: Source code
-#: ../E/object.txt:28
+#: ../E/object.txt:27
 #, no-wrap
 msgid "<code>orientation</code>"
 msgstr "<code>orientation</code>"
 
 #. type: Plain text
-#: ../E/object.txt:29
+#: ../E/object.txt:28
 #, no-wrap
 msgid "Orientation of the object, in degrees. The orientation tells you what direction the object is facing. An orientation of <code>0</code> corresponds to an object facing eastwards, thus following the positive <code>x</code> axis. The orientation is measured counterclockwise. "
 msgstr "Ausrichtung (Gierwinkel) des Objekts in Grad. Die Ausrichtung gibt an, wohin das Objekt schaut. Eine Ausrichtung <code>0</code> entspricht einem Objekt, das nach Osten schaut, also entlang der positiven <code>x-</code>Axe. Der Winkel wird im Gegenuhrzeigersinn gemessen. "
 
 #. type: Source code
-#: ../E/object.txt:31
+#: ../E/object.txt:30
 #, no-wrap
 msgid "<code>pitch</code>"
 msgstr "<code>pitch</code>"
 
 #. type: Plain text
-#: ../E/object.txt:32
+#: ../E/object.txt:31
 #, no-wrap
 msgid "Forward/backward angle of the robot. A pitch of <code>0</code> means that the bot is standing on flat ground. A positive inclination means that it is facing upwards, a negative inclination means that it is facing downwards. "
 msgstr "Nickwinkel (Drehung nach vorne/hinten) des Roboters. Ein Nickwinkel <code>0</code> bedeutet, das der Roboter auf ebener Erde steht. Ein positiver Nickwinkel bedeutet, dass er nach oben schaut, ein negativer nach unten. "
 
 #. type: Source code
-#: ../E/object.txt:34
+#: ../E/object.txt:33
 #, no-wrap
 msgid "<code>roll</code>"
 msgstr "<code>roll</code>"
 
 #. type: Plain text
-#: ../E/object.txt:35
+#: ../E/object.txt:34
 #, no-wrap
 msgid "Left/right angle of the bot, in degrees. A positive value means that the bot is leaning to the left side, a negative value means that it is leaning to the right side. "
 msgstr "Rollwinkel (Neigung nach rechts/links) des Roboters in Grad. Ein positiver Wert bedeutet eine Neigung auf die linke Seite, ein negativer Wert eine Neigung auf die rechte Seite. "
 
 #. type: Source code
-#: ../E/object.txt:37
+#: ../E/object.txt:36
 #, no-wrap
 msgid "<code>energyLevel</code>"
 msgstr "<code>energyLevel</code>"
 
 #. type: Plain text
-#: ../E/object.txt:38
+#: ../E/object.txt:37
 #, no-wrap
 msgid "Energy level, between 0 and 1. A normal <a object|power>power cell</a> that is fully charged returns the value <code>1</code>. A <a object|atomic>nuclear power cell</a> never returns a value higher than 1, it just lasts longer. Attention: The energy level of a bot is always zero, because the energy is not contained in the bot, but in the power cell. To know the energy level of the power cell of a bot, you must write <code>energyCell.energyLevel</code>. "
 msgstr "Energievorrat, zwischen 0 und 1. Eine normale voll geladene <a object|power>elektrolytische Batterie</a> gibt den Wert <code>1</code> zurück. Eine <a object|fuelcell>Brennstoffzelle</a> gibt trotz der größeren Kapazität auch nie einen Wert über <code>1</code> zurück, der Wert sinkt jedoch langsamer. Achtung: der Energievorrat eines Roboters ist immer Null, da die Energie nicht im Roboter, sondern in der Batterie enthalten ist. Um den Vorrat in der Batterie eines Roboters zu erhalten, schreiben Sie <code>energyCell.energyLevel</code>. "
 
 #. type: Source code
-#: ../E/object.txt:40
+#: ../E/object.txt:39
 #, no-wrap
 msgid "<code>shieldLevel</code>"
 msgstr "<code>shieldLevel</code>"
 
 #. type: Plain text
-#: ../E/object.txt:41
+#: ../E/object.txt:40
 #, no-wrap
 msgid ""
 "Shield level of a robot or building. A level <code>1</code> indicates that the shield is still perfect. Every time that the bot or building gets a bullet or collides with another object, the shield level decreases. When the level reaches <code>0</code>, the next bullet or collision will destroy the bot or building. \n"
@@ -2444,49 +2460,49 @@ msgstr ""
 "Roboter können ihren Schaden auf einem <a object|repair>Reparaturzentrum</a> ausbessern lassen. Schäden an Gebäuden und auch Robotern können ausgebessert werden, wenn sie innerhalb der Sphäre eines aktiven <a object|botshld>Schutzschildroboters</a> liegen."
 
 #. type: Source code
-#: ../E/object.txt:44
+#: ../E/object.txt:43
 #, no-wrap
 msgid "<code>temperature</code>"
 msgstr "<code>temperature</code>"
 
 #. type: Plain text
-#: ../E/object.txt:45
+#: ../E/object.txt:44
 #, no-wrap
 msgid "Temperature of the jet of <a object|botgj>winged bots</a>. <code>0</code> corresponds to a cold jet. When used, the temperature increases progressively. When it reaches the value <code>1</code>, the jet is overheated and stops working, until it cooled down a little. "
 msgstr "Triebwerktemperatur von <a object|botgj>Jetrobotern</a>. <code>0</code> entspricht einem kalten Triebwerk. Solange ein Triebwerk in Betrieb ist, steigt die Temperatur ständig. Wenn es den Wert <code>1</code> erreicht, ist es überhitzt und stellt den Betrieb ein, bis es abgekühlt ist."
 
 #. type: Source code
-#: ../E/object.txt:47
+#: ../E/object.txt:46
 #, no-wrap
 msgid "<code>altitude</code>"
 msgstr "<code>altitude</code>"
 
 #. type: Plain text
-#: ../E/object.txt:48
+#: ../E/object.txt:47
 #, no-wrap
 msgid "The <code>z</code> coordinate of the position indicates the altitude above sea level, whereas the <code>altitude</code> indicates the height above ground. This value is meaningful only for <a object|botgj>winged bots</a> and for <a object|wasp>wasps</a>. For all other objects, this value is zero. "
 msgstr "Die <code>z-</code>Koordinate gibt die Höhe über Meeresspiegel an, während <code>altitude</code> die Höhe über Grund angibt. Dieser Wert ist nützlich für <a object|botgj>Jetroboter</a> und für <a object|wasp>Wespen</a>. Für alle anderen Objekte beträgt der Wert Null. "
 
 #. type: Source code
-#: ../E/object.txt:50
+#: ../E/object.txt:49
 #, no-wrap
 msgid "<code>lifeTime</code>"
 msgstr "<code>lifeTime</code>"
 
 #. type: Plain text
-#: ../E/object.txt:51
+#: ../E/object.txt:50
 #, no-wrap
 msgid "The age of the object in seconds since it's creation."
 msgstr "Alter des Objekts in Sekunden seit seiner \"Geburt\"."
 
 #. type: Source code
-#: ../E/object.txt:53
+#: ../E/object.txt:52
 #, no-wrap
 msgid "<code>energyCell</code>"
 msgstr "<code>energyCell</code>"
 
 #. type: Plain text
-#: ../E/object.txt:54
+#: ../E/object.txt:53
 #, no-wrap
 msgid ""
 "This information is special, because it returns the information about another object, in this case the power pack. This means that energyCell contains all the characteristics of a normal object, for example <code>category</code> (PowerCell or NuclearCell), <code>position</code> (the position of the cell), etc.\n"
@@ -2498,31 +2514,31 @@ msgstr ""
 "Wenn der Roboter keine Batterie hat, gibt <code>energyCell</code> den Wert <code>null</code> zurück."
 
 #. type: Source code
-#: ../E/object.txt:58
+#: ../E/object.txt:57
 #, no-wrap
 msgid "<code>load</code>"
 msgstr "<code>load</code>"
 
 #. type: Plain text
-#: ../E/object.txt:59
+#: ../E/object.txt:58
 #, no-wrap
 msgid "This information also returns the description of a whole object: the description of the object carried by a <a object|botgr>grabber</a>. If it carries nothing, <code>load</code> returns <code>null</code>."
 msgstr "Diese Information gibt ebenfalls die Beschreibung eines ganzen Gegenstands zurück, in diesem Fall des Objekts, das ein <a object|botgr>Greifer</a> trägt. Wenn er nichts trägt, gibt <code>load</code> den Wert <code>null</code> zurück."
 
 #. type: \t; header, \b; header
-#: ../E/expr.txt:100 ../E/expr.txt:124 ../E/expr.txt:146 ../E/expr.txt:171 ../E/expr.txt:188 ../E/factory.txt:21 ../E/object.txt:70
+#: ../E/expr.txt:99 ../E/expr.txt:123 ../E/expr.txt:145 ../E/expr.txt:170 ../E/expr.txt:187 ../E/factory.txt:21 ../E/object.txt:66
 #, no-wrap
 msgid "Examples"
 msgstr "Beispiel"
 
 #. type: Plain text
-#: ../E/object.txt:71
+#: ../E/object.txt:67
 #, no-wrap
 msgid "The type <code>object</code> returns the special value <code><a cbot|null>null</a></code> when the object does not exist. For example:"
 msgstr "Der Typ <code>object</code> gibt den speziellen Wert <code><a cbot|null>null</a></code> zurück, wenn das Objekt nicht existiert, z.B.:"
 
 #. type: Source code
-#: ../E/object.txt:73
+#: ../E/object.txt:69
 #, no-wrap
 msgid ""
 "\tobject a;\n"
@@ -5436,7 +5452,7 @@ msgstr ""
 "\t<n/>Anweisung 3<c/>;"
 
 #. type: \t; header
-#: ../E/expr.txt:132 ../E/radar.txt:68
+#: ../E/expr.txt:131 ../E/radar.txt:68
 #, no-wrap
 msgid "Remark"
 msgstr "Bemerkung"
@@ -6355,37 +6371,57 @@ msgid "Use this type for variables that contain the characteristics of an object
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:20
+#: ../E/object.txt:4
+#, no-wrap
+msgid ""
+"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
+"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
+"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
+"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
+"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
+"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
+"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
+"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
+"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
+"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
+"<code>object object.energyCell   </code>Power cell on the bot\n"
+"<code>object object.load         </code>Object carried by the bot\n"
+"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
+"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object"
+msgstr ""
+
+#. type: Plain text
+#: ../E/object.txt:19
 #, no-wrap
 msgid "Also, some objects have additional methods (instructions). See them in <a cbot>the main list</a> in the <c/>\"Instructions specific for some objects\" section."
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:23
+#: ../E/object.txt:22
 #, no-wrap
 msgid "The <n/><a cbot|category>category</a> of an object allows you to know what it is, f. ex. what kind of bot, building, enemy, etc."
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:61
+#: ../E/object.txt:60
 #, no-wrap
 msgid "<code>team</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:62
+#: ../E/object.txt:61
 #, no-wrap
 msgid "The bot's team. Used in <a battles>code battles</a>. If the object has no team assigned (e.g. in no team-based levels, the object being a resource), this is equal to <code>0</code>."
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:64
+#: ../E/object.txt:63
 #, no-wrap
 msgid "<code>velocity</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:65
+#: ../E/object.txt:64
 #, no-wrap
 msgid "Current velocity of the object. Should be treated as a three-dimensional vector."
 msgstr ""
@@ -7296,9 +7332,20 @@ msgid "Binary operators below are working with fundamental number types (<code><
 msgstr ""
 
 #. type: \t; header
-#: ../E/expr.txt:53 ../E/expr.txt:90 ../E/expr.txt:116 ../E/expr.txt:141 ../E/expr.txt:164
+#: ../E/expr.txt:53 ../E/expr.txt:89 ../E/expr.txt:115 ../E/expr.txt:140 ../E/expr.txt:163
 #, no-wrap
 msgid "List"
+msgstr ""
+
+#. type: Plain text
+#: ../E/expr.txt:54
+#, no-wrap
+msgid ""
+"<code>+</code>  addition\n"
+"<code>-</code>  subtraction\n"
+"<code>*</code>  multiplication\n"
+"<code>/</code>  division\n"
+"<code>%</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
 msgstr ""
 
 #. type: \t; header
@@ -7326,49 +7373,49 @@ msgid "Real life examples"
 msgstr ""
 
 #. type: \t; header
-#: ../E/expr.txt:82
+#: ../E/expr.txt:81
 #, no-wrap
 msgid "Compound assignment operators"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:83
+#: ../E/expr.txt:82
 #, no-wrap
 msgid "Besides the <code>=</code> operator for variable assignment there are several compound-assignment operators."
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:85
+#: ../E/expr.txt:84
 #, no-wrap
 msgid "The compound-assignment operators combine the <code>=</code> assignment operator with another binary operator such as <code>+</code> or <code>-</code>. Compound-assignment operators perform the operation specified by the additional operator and then assign the result to the left operand. For example, a compound-assignment expression such as"
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:86
+#: ../E/expr.txt:85
 #, no-wrap
 msgid "<code>lvalue += expression</code>"
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:88
+#: ../E/expr.txt:87
 #, no-wrap
 msgid "<code>lvalue = lvalue + expression</code>"
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:97
+#: ../E/expr.txt:96
 #, no-wrap
 msgid "String concatenation"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:98
+#: ../E/expr.txt:97
 #, no-wrap
 msgid "If at least one of the values used with the <code>+</code> operator is a <a cbot|string>string</a>, then the operation of concatenation is performed. The result of the operator is then a string, which is created by joining end-to-end the string and the other value. If the other value is not a string, then it is converted to string beforehand."
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:102
+#: ../E/expr.txt:101
 #, no-wrap
 msgid ""
 "\tstring s = \"a\" + \"bc\";  // returns \"abc\"\n"
@@ -7378,43 +7425,43 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:107
+#: ../E/expr.txt:106
 #, no-wrap
 msgid "Tip: the properties of the concatenation <code>+</code> operator is useful with the <a cbot|message>message();</a> function, because it does not work with other types than string. An empty string can be used together with a value in order to create a string, which actually can be passed to the <a cbot|message>message();</a> function:"
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:178
+#: ../E/expr.txt:177
 #, no-wrap
 msgid "Prefix and postfix increment- and decrement operators"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:181
+#: ../E/expr.txt:180
 #, no-wrap
 msgid "For example to increment the variable <code>a</code> you can write"
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:182
+#: ../E/expr.txt:181
 #, no-wrap
 msgid "<c/>a++;<n/>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:183
+#: ../E/expr.txt:182
 #, no-wrap
 msgid "instead of"
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:184
+#: ../E/expr.txt:183
 #, no-wrap
 msgid "<c/>a = a + 1;<n/>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:186
+#: ../E/expr.txt:185
 #, no-wrap
 msgid "The result of the operation <code>a++</code> is the value of the variable <code>a</code> *before* the increment. If you use the prefix operator <code>++a</code> the result of the operation is the value of the variable <code>a</code> *after* the increment. The same holds for the <code>--</code> decrement operator."
 msgstr ""
@@ -7438,7 +7485,27 @@ msgid "Note: it may be not obvious at first, but notice that <code>=</code> is a
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:109
+#: ../E/expr.txt:66
+#, no-wrap
+msgid ""
+" int    i = 12 + 3;      // i == 15\n"
+" int    i = 2 - 5;       // i == -3\n"
+" \n"
+" float  f = 3.01 * 10;   // f == 30.1\n"
+" \n"
+" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
+" float  f = 5 / 3;       // f == 1.67\n"
+" float  f = 5 / 0;       // returns an error (division by zero)\n"
+" \n"
+" int    i = 13 % 5;      // i == 3\n"
+" int    i = -8 % 3;      // i == -2\n"
+" \n"
+" float  f = sin(90) * i; // f == -2.0\n"
+" "
+msgstr ""
+
+#. type: Source code
+#: ../E/expr.txt:108
 #, no-wrap
 msgid ""
 " float pi = 3.14;\n"
@@ -7447,7 +7514,7 @@ msgid ""
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:190
+#: ../E/expr.txt:189
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -7456,7 +7523,7 @@ msgid ""
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:194
+#: ../E/expr.txt:193
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -7465,25 +7532,25 @@ msgid ""
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:138
+#: ../E/expr.txt:137
 #, no-wrap
 msgid "Logical operators"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:139
+#: ../E/expr.txt:138
 #, no-wrap
 msgid "Logical operators work with values of type <a cbot|bool>bool</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:151
+#: ../E/expr.txt:150
 #, no-wrap
 msgid "Ternary operator"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:152
+#: ../E/expr.txt:151
 #, no-wrap
 msgid ""
 "The ternary operator is nothing more than a syntax sugar. It is also known as \"inline if\". It might be confusing at first, because its syntax is a little more complicated than other operators. It can be described as follows:\n"
@@ -7492,19 +7559,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:156
+#: ../E/expr.txt:155
 #, no-wrap
 msgid "Firstly, the condition is valued and then the first result is returned if the condition is true, otherwise the second result is returned."
 msgstr ""
 
 #. type: \t; header
-#: ../E/expr.txt:158 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
+#: ../E/expr.txt:157 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
 #, no-wrap
 msgid "Example"
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:159
+#: ../E/expr.txt:158
 #, no-wrap
 msgid "<c/>float c = ((3.0 > 2.0) ? 10.0 : -10.0); // c == 10.0<n/>"
 msgstr ""
@@ -7516,19 +7583,19 @@ msgid "A condition is a special <a cbot|expr>expression</a> that returns a <a cb
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:113
+#: ../E/expr.txt:112
 #, no-wrap
 msgid "Comparison operators"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:114
+#: ../E/expr.txt:113
 #, no-wrap
 msgid "Comparison operators work with values of type <a cbot|bool>float</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:142
+#: ../E/expr.txt:141
 #, no-wrap
 msgid ""
 "<code>!a      </code>not <code>a</code>\n"
@@ -7537,7 +7604,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:147
+#: ../E/expr.txt:146
 #, no-wrap
 msgid ""
 "<code>!false        </code>returns true\n"
@@ -7546,19 +7613,19 @@ msgid ""
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:161
+#: ../E/expr.txt:160
 #, no-wrap
 msgid "Bitwise operators"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:162
+#: ../E/expr.txt:161
 #, no-wrap
 msgid "Bitwise operators are similar to the logical operator, because they are operating on bits (which can be only 0 or 1, conditions can have a value only of false or true). So in theory, they should be working with basically any type of variable, because each value in the computer must be stored as a sequence of bits."
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:165
+#: ../E/expr.txt:164
 #, no-wrap
 msgid ""
 "<code>a & b  </code><code>a</code> AND <code>b</code>\n"
@@ -7569,7 +7636,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:172
+#: ../E/expr.txt:171
 #, no-wrap
 msgid ""
 "<code>2 & 1         </code>returns 0\n"
@@ -8840,90 +8907,4 @@ msgid ""
 " {\n"
 "     factory(WheeledGrabber, \"program/say-foo.cbot\");\n"
 " }"
-msgstr ""
-
-#. type: Plain text
-#: ../E/expr.txt:54
-#, no-wrap
-msgid ""
-"<code>+</code>  addition\n"
-"<code>-</code>  subtraction\n"
-"<code>*</code>  multiplication\n"
-"<code>/</code>  division\n"
-"<code>%</code>  remainder of the division (works for <code><a cbot|int>int</a></code> as well as <code><a cbot|float>float</a></code>)"
-msgstr ""
-"<code>+=</code>  addieren\n"
-"<code>-=</code>  subtrahieren\n"
-"<code>*=</code>  multiplizieren\n"
-"<code>/=</code>  dividieren\n"
-"<code>%=</code>  Rest der Division (Funktioniert sowohl für <code><a cbot|int>int</a></code> als auch <code><a cbot|float>float</a></code>)"
-
-#. type: Source code
-#: ../E/expr.txt:66
-#, no-wrap
-msgid ""
-" int    i = 12 + 3;      // i == 15\n"
-" int    i = 2 - 5;       // i == -3\n"
-" \n"
-" float  f = 3.01 * 10;   // f == 30.1\n"
-" \n"
-" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
-" float  f = 5 / 3;       // f == 1.67\n"
-" float  f = 5 / 0;       // returns an error (division by zero)\n"
-" \n"
-" int    i = 13 % 5;      // i == 3\n"
-" int    i = -8 % 3;      // i == -2\n"
-" float  f = -4.5 % 2.75; // f == -1.75\n"
-" \n"
-" float  f = sin(90) * i; // f == -2.0\n"
-" "
-msgstr ""
-
-#. type: Plain text
-#: ../E/expr.txt:91
-#, no-wrap
-msgid ""
-"<code>+=</code>  addition\n"
-"<code>-=</code>  subtraction\n"
-"<code>*=</code>  multiplication\n"
-"<code>/=</code>  division\n"
-"<code>%=</code>  remainder of the division"
-msgstr ""
-"<code>+=</code>  addieren\n"
-"<code>-=</code>  subtrahieren\n"
-"<code>*=</code>  multiplizieren\n"
-"<code>/=</code>  dividieren\n"
-"<code>%=</code>  Rest der Division"
-
-#. type: Plain text
-#: ../E/object.txt:4
-#, no-wrap
-msgid ""
-"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
-"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
-"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
-"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
-"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
-"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
-"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
-"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
-"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
-"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
-"<code>object object.energyCell   </code>Power cell on the bot\n"
-"<code>object object.load         </code>Object carried by the bot\n"
-"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
-"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object\n"
-"<code><a cbot|bool>bool</a>   object.dead         </code>Is the object dead?"
-msgstr ""
-
-#. type: Source code
-#: ../E/object.txt:67
-#, no-wrap
-msgid "<code>dead</code>"
-msgstr ""
-
-#. type: Plain text
-#: ../E/object.txt:68
-#, no-wrap
-msgid "True if the object was recently killed (while the death animation is playing). Note that accessing this property or any other property after the death animation finishes will cause an error that stops the program."
 msgstr ""

--- a/help/cbot/po/fr.po
+++ b/help/cbot/po/fr.po
@@ -9085,13 +9085,13 @@ msgstr ""
 #: ../E/factory.txt:5
 #, no-wrap
 msgid "Starts a construction of a bot of a given <a cbot|category>category</a> and runs a specified program on it after the construction is finished."
-msgstr "Démarre la construction d'un bot d'une <a cbot|category>catégorie</a> donnée et exécute un programme spécifié sur celui-ci une fois la construction terminée."
+msgstr ""
 
 #. type: Plain text
 #: ../E/factory.txt:14
 #, no-wrap
 msgid "<a object|factory>BotFactory</a>, nearest by default."
-msgstr "<a object|factory>BotFactory</a>, le plus proche par défaut."
+msgstr ""
 
 #. type: Plain text
 #: ../E/factory.txt:62
@@ -9327,13 +9327,13 @@ msgstr ""
 #: ../E/factory.txt:11
 #, no-wrap
 msgid "Program that will be run on the bot after factory finishes the construction. This can be either a <a cbot|public>public</a> <a cbot|function>function</a>, a filename or raw code."
-msgstr "Programme qui sera exécuté sur le bot une fois la construction terminée en usine. Il peut s'agir d'une <a cbot|function>fonction</a> <a cbot|public>publique</a>, d'un nom de fichier ou d'un extrait de code."
+msgstr ""
 
 #. type: Plain text
 #: ../E/factory.txt:23
 #, no-wrap
 msgid "Raw code:"
-msgstr "Extrait de code:"
+msgstr ""
 
 #. type: Source code
 #: ../E/factory.txt:25
@@ -9349,7 +9349,7 @@ msgstr ""
 #: ../E/factory.txt:31
 #, no-wrap
 msgid "Public function:"
-msgstr "Fonction publique:"
+msgstr ""
 
 #. type: Source code
 #: ../E/factory.txt:33
@@ -9370,13 +9370,13 @@ msgstr ""
 #: ../E/factory.txt:44
 #, no-wrap
 msgid "File name:"
-msgstr "Nom du fichier:"
+msgstr ""
 
 #. type: Plain text
 #: ../E/factory.txt:46
 #, no-wrap
 msgid "Save this as say-foo.cbot. Note: make sure to check the \"Public\" checkbox when saving - this will cause say-foo.cbot to be inside the program/ folder."
-msgstr "Enregistrez-le sous le nom say-foo.cbot. Remarque : assurez-vous de cocher la case « Public » lors de l'enregistrement - cela entraînera la présence de say-foo.cbot dans le dossier program/."
+msgstr ""
 
 #. type: Source code
 #: ../E/factory.txt:48
@@ -9392,7 +9392,7 @@ msgstr ""
 #: ../E/factory.txt:54
 #, no-wrap
 msgid "Run factory like this:"
-msgstr "Utilisez la fonction factory ceci:"
+msgstr ""
 
 #. type: Source code
 #: ../E/factory.txt:56

--- a/help/cbot/po/fr.po
+++ b/help/cbot/po/fr.po
@@ -54,13 +54,13 @@ msgid "Time in seconds."
 msgstr "Temps en secondes."
 
 #. type: \t; header
-#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:197 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:79 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
+#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:198 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:83 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
 #, no-wrap
 msgid "See also"
 msgstr "Voir aussi"
 
 #. type: Plain text
-#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:198 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:80 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
+#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:199 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:84 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
 #, no-wrap
 msgid "<a cbot>Programming</a>, <a cbot|type>types</a> and <a cbot|category>categories</a>."
 msgstr "<a cbot>Programmation</a>, <a cbot|type>types</a> et <a cbot|category>catégories</a>."
@@ -616,7 +616,7 @@ msgid "Conditions"
 msgstr "Les conditions"
 
 #. type: Plain text
-#: ../E/expr.txt:116
+#: ../E/expr.txt:117
 #, no-wrap
 msgid ""
 "<code>a == b  </code><code>a</code> equals <code>b</code>\n"
@@ -634,7 +634,7 @@ msgstr ""
 "<code>a >= b  </code><code>a</code> plus grand ou égal à <code>b</code>"
 
 #. type: Plain text
-#: ../E/expr.txt:124
+#: ../E/expr.txt:125
 #, no-wrap
 msgid ""
 "<code>12 == 12  </code>returns true\n"
@@ -652,13 +652,13 @@ msgstr ""
 "<code>12 >= 12  </code>retourne vrai"
 
 #. type: Plain text
-#: ../E/expr.txt:132
+#: ../E/expr.txt:133
 #, no-wrap
 msgid "Be careful not to confuse the equality comparison <code>==</code> with the assignment of a <a cbot|var>variable</a> <code>=</code>."
 msgstr "Il faut faire très attention à ne pas confondre la comparaison d'égalité <code>==</code> avec l'affectation d'une <a cbot|var>variable</a> <code>=</code>."
 
 #. type: Plain text
-#: ../E/expr.txt:134
+#: ../E/expr.txt:135
 #, no-wrap
 msgid ""
 "<code>a == b</code> is an expression that compares <code>a</code> with <code>b</code>.\n"
@@ -1263,29 +1263,13 @@ msgid "Expressions"
 msgstr "Les expressions"
 
 #. type: Plain text
-#: ../E/expr.txt:86
+#: ../E/expr.txt:87
 #, no-wrap
 msgid "is equivalent to"
 msgstr "est équivalent à"
 
 #. type: Plain text
-#: ../E/expr.txt:90
-#, no-wrap
-msgid ""
-"<code>+=</code>  addition\n"
-"<code>-=</code>  subtraction\n"
-"<code>*=</code>  multiplication\n"
-"<code>/=</code>  division\n"
-"<code>%=</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
-msgstr ""
-"<code>+=</code>  addition\n"
-"<code>-=</code>  soustraction\n"
-"<code>*=</code>  multiplication\n"
-"<code>/=</code>  division\n"
-"<code>%=</code>  reste de la division (seulement pour le type <code><a cbot|int>int</a></code>)"
-
-#. type: Plain text
-#: ../E/expr.txt:178
+#: ../E/expr.txt:179
 #, no-wrap
 msgid "The operators <code>++</code> and <code>--</code> allow you to increment (++) or to decrement (--) a variable in very compact and efficient manner."
 msgstr "Les opérateurs <code>++</code> et <code>--</code> permettent d'incrémenter (++) ou décrémenter (--) une variable de manière particulièrement compacte et efficace."
@@ -2426,67 +2410,67 @@ msgid "Type <code>object</code>"
 msgstr "Type <code>object</code>"
 
 #. type: Source code
-#: ../E/object.txt:21
+#: ../E/object.txt:22
 #, no-wrap
 msgid "<code>category</code>"
 msgstr "<code>category</code>"
 
 #. type: Source code
-#: ../E/object.txt:24
+#: ../E/object.txt:25
 #, no-wrap
 msgid "<code>position</code>"
 msgstr "<code>position</code>"
 
 #. type: Plain text
-#: ../E/object.txt:25
+#: ../E/object.txt:26
 #, no-wrap
 msgid "Position of the object on the planet, in meters. The coordinates <code>x</code> and <code>y</code> correspond to the location on a map, the <code>z</code> coordinate corresponds to the altitude above (respectively below) sea level. "
 msgstr "Position de l'objet sur la planète, en mètres. Les coordonnées <code>x</code> et <code>y</code> correspondent à la position à plat, alors que <code>z</code> correspond à l'élévation absolue par rapport au niveau de la mer."
 
 #. type: Source code
-#: ../E/object.txt:27
+#: ../E/object.txt:28
 #, no-wrap
 msgid "<code>orientation</code>"
 msgstr "<code>orientation</code>"
 
 #. type: Plain text
-#: ../E/object.txt:28
+#: ../E/object.txt:29
 #, no-wrap
 msgid "Orientation of the object, in degrees. The orientation tells you what direction the object is facing. An orientation of <code>0</code> corresponds to an object facing eastwards, thus following the positive <code>x</code> axis. The orientation is measured counterclockwise. "
 msgstr "Orientation de l'objet, en degrés. Une orientation de <code>0</code> correspond à un objet tourné vers l'est, donc vers l'axe <code>x</code> positif. Le sens de l'orientation est anti-horaire."
 
 #. type: Source code
-#: ../E/object.txt:30
+#: ../E/object.txt:31
 #, no-wrap
 msgid "<code>pitch</code>"
 msgstr "<code>pitch</code>"
 
 #. type: Plain text
-#: ../E/object.txt:31
+#: ../E/object.txt:32
 #, no-wrap
 msgid "Forward/backward angle of the robot. A pitch of <code>0</code> means that the bot is standing on flat ground. A positive inclination means that it is facing upwards, a negative inclination means that it is facing downwards. "
 msgstr "Inclinaison avant/arrière de l'objet, en degrés. Une valeur positive indique que le robot monte."
 
 #. type: Source code
-#: ../E/object.txt:33
+#: ../E/object.txt:34
 #, no-wrap
 msgid "<code>roll</code>"
 msgstr "<code>roll</code>"
 
 #. type: Plain text
-#: ../E/object.txt:34
+#: ../E/object.txt:35
 #, no-wrap
 msgid "Left/right angle of the bot, in degrees. A positive value means that the bot is leaning to the left side, a negative value means that it is leaning to the right side. "
 msgstr "Inclinaison latérale de l'objet, en degrés. Une valeur positive indique que le robot penche à gauche."
 
 #. type: Source code
-#: ../E/object.txt:36
+#: ../E/object.txt:37
 #, no-wrap
 msgid "<code>energyLevel</code>"
 msgstr "<code>energyLevel</code>"
 
 #. type: Plain text
-#: ../E/object.txt:37
+#: ../E/object.txt:38
 #, no-wrap
 msgid "Energy level, between 0 and 1. A normal <a object|power>power cell</a> that is fully charged returns the value <code>1</code>. A <a object|atomic>nuclear power cell</a> never returns a value higher than 1, it just lasts longer. Attention: The energy level of a bot is always zero, because the energy is not contained in the bot, but in the power cell. To know the energy level of the power cell of a bot, you must write <code>energyCell.energyLevel</code>. "
 msgstr ""
@@ -2494,13 +2478,13 @@ msgstr ""
 "Notez que le niveau d'énergie d'un robot est toujours nul. En effet, l'énergie est contenue dans la pile ou la batterie qui est placée à l'arrière du robot, et non dans le robot lui-même. Il faut donc écrire <code>energyCell.energyLevel</code> pour connaître l'énergie à disposition."
 
 #. type: Source code
-#: ../E/object.txt:39
+#: ../E/object.txt:40
 #, no-wrap
 msgid "<code>shieldLevel</code>"
 msgstr "<code>shieldLevel</code>"
 
 #. type: Plain text
-#: ../E/object.txt:40
+#: ../E/object.txt:41
 #, no-wrap
 msgid ""
 "Shield level of a robot or building. A level <code>1</code> indicates that the shield is still perfect. Every time that the bot or building gets a bullet or collides with another object, the shield level decreases. When the level reaches <code>0</code>, the next bullet or collision will destroy the bot or building. \n"
@@ -2510,49 +2494,49 @@ msgstr ""
 "Les robots peuvent régénérer leurs boucliers sur le <a object|repair>centre de réparation</a>. Le bouclier d'un bâtiment est régénéré s'il se trouve dans la sphère protectrice du <a object|botshld>robot bouclier</a>."
 
 #. type: Source code
-#: ../E/object.txt:43
+#: ../E/object.txt:44
 #, no-wrap
 msgid "<code>temperature</code>"
 msgstr "<code>temperature</code>"
 
 #. type: Plain text
-#: ../E/object.txt:44
+#: ../E/object.txt:45
 #, no-wrap
 msgid "Temperature of the jet of <a object|botgj>winged bots</a>. <code>0</code> corresponds to a cold jet. When used, the temperature increases progressively. When it reaches the value <code>1</code>, the jet is overheated and stops working, until it cooled down a little. "
 msgstr "Température du réacteur pour les <a object|botgj>robots volants</a>. <code>0</code> correspond à un réacteur froid et <code>1</code> à un réacteur bouillant, provisoirement hors d'usage."
 
 #. type: Source code
-#: ../E/object.txt:46
+#: ../E/object.txt:47
 #, no-wrap
 msgid "<code>altitude</code>"
 msgstr "<code>altitude</code>"
 
 #. type: Plain text
-#: ../E/object.txt:47
+#: ../E/object.txt:48
 #, no-wrap
 msgid "The <code>z</code> coordinate of the position indicates the altitude above sea level, whereas the <code>altitude</code> indicates the height above ground. This value is meaningful only for <a object|botgj>winged bots</a> and for <a object|wasp>wasps</a>. For all other objects, this value is zero. "
 msgstr "Contrairement à la position <code>z</code> qui est absolue, l'altitude est relative au niveau du sol. L'altitude n'a de sens que pour les <a object|botgj>robots volants</a> et la <a object|wasp>guêpe</a>. Pour tous les autres robots ou pour les bâtiments, cette valeur est nulle."
 
 #. type: Source code
-#: ../E/object.txt:49
+#: ../E/object.txt:50
 #, no-wrap
 msgid "<code>lifeTime</code>"
 msgstr "<code>lifeTime</code>"
 
 #. type: Plain text
-#: ../E/object.txt:50
+#: ../E/object.txt:51
 #, no-wrap
 msgid "The age of the object in seconds since it's creation."
 msgstr "Donne l'âge de l'objet, en secondes."
 
 #. type: Source code
-#: ../E/object.txt:52
+#: ../E/object.txt:53
 #, no-wrap
 msgid "<code>energyCell</code>"
 msgstr "<code>energyCell</code>"
 
 #. type: Plain text
-#: ../E/object.txt:53
+#: ../E/object.txt:54
 #, no-wrap
 msgid ""
 "This information is special, because it returns the information about another object, in this case the power pack. This means that energyCell contains all the characteristics of a normal object, for example <code>category</code> (PowerCell or NuclearCell), <code>position</code> (the position of the cell), etc.\n"
@@ -2564,31 +2548,31 @@ msgstr ""
 "Si le robot n'a pas de pile ni de batterie, <code>energyCell</code> vaut <code>null</code>."
 
 #. type: Source code
-#: ../E/object.txt:57
+#: ../E/object.txt:58
 #, no-wrap
 msgid "<code>load</code>"
 msgstr "<code>load</code>"
 
 #. type: Plain text
-#: ../E/object.txt:58
+#: ../E/object.txt:59
 #, no-wrap
 msgid "This information also returns the description of a whole object: the description of the object carried by a <a object|botgr>grabber</a>. If it carries nothing, <code>load</code> returns <code>null</code>."
 msgstr "Cette information est spéciale, comme la précédente. Elle contient les caractéristiques de l'objet transporté par le <a object|botgr>robot préhenseur</a>. S'il ne transporte rien, <code>load</code> vaut <code>null</code>."
 
 #. type: \t; header, \b; header
-#: ../E/expr.txt:99 ../E/expr.txt:123 ../E/expr.txt:145 ../E/expr.txt:170 ../E/expr.txt:187 ../E/factory.txt:21 ../E/object.txt:66
+#: ../E/expr.txt:100 ../E/expr.txt:124 ../E/expr.txt:146 ../E/expr.txt:171 ../E/expr.txt:188 ../E/factory.txt:21 ../E/object.txt:70
 #, no-wrap
 msgid "Examples"
 msgstr "Examples"
 
 #. type: Plain text
-#: ../E/object.txt:67
+#: ../E/object.txt:71
 #, no-wrap
 msgid "The type <code>object</code> returns the special value <code><a cbot|null>null</a></code> when the object does not exist. For example:"
 msgstr "Le type <code>object</code> prend la valeur particulière <code><a cbot|null>null</a></code> lorsque l'objet n'existe pas. Par exemple:"
 
 #. type: Source code
-#: ../E/object.txt:69
+#: ../E/object.txt:73
 #, no-wrap
 msgid ""
 "\tobject a;\n"
@@ -3213,7 +3197,7 @@ msgid "Returns the first object found that corresponds to the specified category
 msgstr "Objet trouvé le plus proche. La valeur <code><a cbot|null>null</a></code> indique que rien n'a été trouvé."
 
 #. type: \t; header
-#: ../E/expr.txt:131 ../E/radar.txt:68
+#: ../E/expr.txt:132 ../E/radar.txt:68
 #, no-wrap
 msgid "Remark"
 msgstr "Remarque"
@@ -6496,71 +6480,37 @@ msgid "Use this type for variables that contain the characteristics of an object
 msgstr "Utilisez ce type pour les variables qui contiennent les caractéristiques d'un objet, que ce soit un robot, un bâtiment, une matière première, un ennemi, etc. Voici toutes les propriétés d'un objet : "
 
 #. type: Plain text
-#: ../E/object.txt:4
-#, no-wrap
-msgid ""
-"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
-"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
-"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
-"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
-"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
-"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
-"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
-"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
-"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
-"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
-"<code>object object.energyCell   </code>Power cell on the bot\n"
-"<code>object object.load         </code>Object carried by the bot\n"
-"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
-"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object"
-msgstr ""
-"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Catégorie</a> de l'objet\n"
-"<code><a cbot|point>point</a>  object.position     </code>Position de l'objet (x,y,z)\n"
-"<code><a cbot|float>float</a>  object.orientation  </code>Orientation de l'objet (0..360)\n"
-"<code><a cbot|float>float</a>  object.pitch        </code>Angle de bascule de l'objet\n"
-"<code><a cbot|float>float</a>  object.roll         </code>Angle d'inclinaison de l'object \n"
-"<code><a cbot|float>float</a>  object.energyLevel  </code>Niveau d'énergie (0..1)\n"
-"<code><a cbot|float>float</a>  object.shieldLevel  </code>Niveau de bouclier (0..1)\n"
-"<code><a cbot|float>float</a>  object.temperature  </code>Chaleur du jet (0..1)\n"
-"<code><a cbot|float>float</a>  object.altitude     </code>Altitude par rapport au sol\n"
-"<code><a cbot|float>float</a>  object.lifeTime     </code>Durée de vie de l'objet\n"
-"<code>object object.energyCell   </code>batterie ou pile du robot\n"
-"<code>object object.load         </code>Objet transporté par le préhenseur\n"
-"<code><a cbot|int>int</a>    object.team         </code>Équipe de l'objet (Voir <a battles>batailles de code</a>)\n"
-"<code><a cbot|point>point</a>  object.velocity     </code>Vitesse de l'objet"
-
-#. type: Plain text
-#: ../E/object.txt:19
+#: ../E/object.txt:20
 #, no-wrap
 msgid "Also, some objects have additional methods (instructions). See them in <a cbot>the main list</a> in the <c/>\"Instructions specific for some objects\" section."
 msgstr "De plus, certains objets ont des méthodes (instructions) supplémentaires. Se reporter à la <a cbot>la liste principale</a> dans la section <c/>\"Instructions spécifiques pour certains objets\"."
 
 #. type: Plain text
-#: ../E/object.txt:22
+#: ../E/object.txt:23
 #, no-wrap
 msgid "The <n/><a cbot|category>category</a> of an object allows you to know what it is, f. ex. what kind of bot, building, enemy, etc."
 msgstr "<n/>La <a cbot|category>catégorie</a> d'un objet vous permet de savoir de quoi il s'agit, par exemple de quel type de robot, bâtiment, ennemi, etc."
 
 #. type: Source code
-#: ../E/object.txt:60
+#: ../E/object.txt:61
 #, no-wrap
 msgid "<code>team</code>"
 msgstr "<code>team</code>"
 
 #. type: Plain text
-#: ../E/object.txt:61
+#: ../E/object.txt:62
 #, no-wrap
 msgid "The bot's team. Used in <a battles>code battles</a>. If the object has no team assigned (e.g. in no team-based levels, the object being a resource), this is equal to <code>0</code>."
 msgstr "L'équipe du robot. Utilisé dans <a battles>bataille de codes</a>. Si l'objet n'a pas d'équipe affectée (par exemple, dans les niveau non basé sur les équipes ou l'objet étant une ressource), ceci est égal à <code>0</code>."
 
 #. type: Source code
-#: ../E/object.txt:63
+#: ../E/object.txt:64
 #, no-wrap
 msgid "<code>velocity</code>"
 msgstr "<code>velocity</code>"
 
 #. type: Plain text
-#: ../E/object.txt:64
+#: ../E/object.txt:65
 #, no-wrap
 msgid "Current velocity of the object. Should be treated as a three-dimensional vector."
 msgstr "Vitesse actuelle de l'objet, dans chacun des axes x,y et z. Doit être traité comme un vecteur tridimensionnel."
@@ -7574,26 +7524,10 @@ msgid "Binary operators below are working with fundamental number types (<code><
 msgstr "Les opérateurs binaires ci-dessous fonctionnent avec les types de nombres fondamentaux (<code><a cbot|int>int</a></code>, <code><a cbot|float>float</a></code>)."
 
 #. type: \t; header
-#: ../E/expr.txt:53 ../E/expr.txt:89 ../E/expr.txt:115 ../E/expr.txt:140 ../E/expr.txt:163
+#: ../E/expr.txt:53 ../E/expr.txt:90 ../E/expr.txt:116 ../E/expr.txt:141 ../E/expr.txt:164
 #, no-wrap
 msgid "List"
 msgstr "Listes"
-
-#. type: Plain text
-#: ../E/expr.txt:54
-#, no-wrap
-msgid ""
-"<code>+</code>  addition\n"
-"<code>-</code>  subtraction\n"
-"<code>*</code>  multiplication\n"
-"<code>/</code>  division\n"
-"<code>%</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
-msgstr ""
-"<code>+</code>  addition\n"
-"<code>-</code>   soustraction\n"
-"<code>*</code>  multiplication\n"
-"<code>/</code>   division\n"
-"<code>%</code>  reste de la division ( seulement pour le type <code><a cbot|int>int</a></code>)"
 
 #. type: \t; header
 #: ../E/expr.txt:60
@@ -7622,49 +7556,49 @@ msgid "Real life examples"
 msgstr "Exemples dans la vie réelle"
 
 #. type: \t; header
-#: ../E/expr.txt:81
+#: ../E/expr.txt:82
 #, no-wrap
 msgid "Compound assignment operators"
 msgstr "Opérateurs d'assignation composée"
 
 #. type: Plain text
-#: ../E/expr.txt:82
+#: ../E/expr.txt:83
 #, no-wrap
 msgid "Besides the <code>=</code> operator for variable assignment there are several compound-assignment operators."
 msgstr "En plus de l'opérateur <code>=</code> pour l'assignation de variables, il existe plusieurs opérateurs d'assignation composée."
 
 #. type: Plain text
-#: ../E/expr.txt:84
+#: ../E/expr.txt:85
 #, no-wrap
 msgid "The compound-assignment operators combine the <code>=</code> assignment operator with another binary operator such as <code>+</code> or <code>-</code>. Compound-assignment operators perform the operation specified by the additional operator and then assign the result to the left operand. For example, a compound-assignment expression such as"
 msgstr "Les opérateurs d'assignation composée combinent l'opérateur assignation <code>=</code> avec un autre opérateur binaire tel que <code>+</code> ou <code>-</code>. Les opérateurs d'assignation composée effectuent l'opération spécifiée par l'opérateur supplémentaire et affectent ensuite le résultat à l'opérande de gauche. Par exemple, une expression d'affectation composée telle que"
 
 #. type: Source code
-#: ../E/expr.txt:85
+#: ../E/expr.txt:86
 #, no-wrap
 msgid "<code>lvalue += expression</code>"
 msgstr "<code>lvalue += expression</code>"
 
 #. type: Source code
-#: ../E/expr.txt:87
+#: ../E/expr.txt:88
 #, no-wrap
 msgid "<code>lvalue = lvalue + expression</code>"
 msgstr "<code>lvalue = lvalue + expression</code>"
 
 #. type: \b; header
-#: ../E/expr.txt:96
+#: ../E/expr.txt:97
 #, no-wrap
 msgid "String concatenation"
 msgstr "Concaténation de chaînes (string)"
 
 #. type: Plain text
-#: ../E/expr.txt:97
+#: ../E/expr.txt:98
 #, no-wrap
 msgid "If at least one of the values used with the <code>+</code> operator is a <a cbot|string>string</a>, then the operation of concatenation is performed. The result of the operator is then a string, which is created by joining end-to-end the string and the other value. If the other value is not a string, then it is converted to string beforehand."
 msgstr "Si au moins une des valeurs utilisées avec l'opérateur <code>+</code> est un <a cbot|string>string</a>, l'opération de concaténation est effectuée. Le résultat de l'opérateur est alors une chaîne, qui est créée en joignant la chaîne de bout en bout et l'autre valeur. Si l'autre valeur n'est pas une chaîne de caractères, elle est convertie en chaîne au préalable."
 
 #. type: Source code
-#: ../E/expr.txt:101
+#: ../E/expr.txt:102
 #, no-wrap
 msgid ""
 "\tstring s = \"a\" + \"bc\";  // returns \"abc\"\n"
@@ -7678,43 +7612,43 @@ msgstr ""
 "\tstring s = \"a\" + true;    // retourne \"atrue\""
 
 #. type: Plain text
-#: ../E/expr.txt:106
+#: ../E/expr.txt:107
 #, no-wrap
 msgid "Tip: the properties of the concatenation <code>+</code> operator is useful with the <a cbot|message>message();</a> function, because it does not work with other types than string. An empty string can be used together with a value in order to create a string, which actually can be passed to the <a cbot|message>message();</a> function:"
 msgstr "Astuce : les propriétés de l'opérateur concaténation <code>+</code> sont utiles avec la fonction <a cbot|message>message();</a>, car elle ne fonctionne pas avec d'autres types que la chaîne. Une chaîne vide peut être utilisée avec une valeur pour créer une chaîne, qui peut être passée à la fonction <a cbot|message>message();</a> :"
 
 #. type: \b; header
-#: ../E/expr.txt:177
+#: ../E/expr.txt:178
 #, no-wrap
 msgid "Prefix and postfix increment- and decrement operators"
 msgstr "Opérateurs préfixés et postfixés d'incrémentation et de décrémentation"
 
 #. type: Plain text
-#: ../E/expr.txt:180
+#: ../E/expr.txt:181
 #, no-wrap
 msgid "For example to increment the variable <code>a</code> you can write"
 msgstr "Par exemple pour pré-incrémenter la variable <code>a</code> vous pouvez écrire"
 
 #. type: Source code
-#: ../E/expr.txt:181
+#: ../E/expr.txt:182
 #, no-wrap
 msgid "<c/>a++;<n/>"
 msgstr "<c/>a++;<n/>"
 
 #. type: Plain text
-#: ../E/expr.txt:182
+#: ../E/expr.txt:183
 #, no-wrap
 msgid "instead of"
 msgstr "au lieu de"
 
 #. type: Source code
-#: ../E/expr.txt:183
+#: ../E/expr.txt:184
 #, no-wrap
 msgid "<c/>a = a + 1;<n/>"
 msgstr "<c/>a = a + 1;<n/>"
 
 #. type: Plain text
-#: ../E/expr.txt:185
+#: ../E/expr.txt:186
 #, no-wrap
 msgid "The result of the operation <code>a++</code> is the value of the variable <code>a</code> *before* the increment. If you use the prefix operator <code>++a</code> the result of the operation is the value of the variable <code>a</code> *after* the increment. The same holds for the <code>--</code> decrement operator."
 msgstr "Le résultat de l'opération <code>a++</code> est la valeur de la variable <code>a</code> *avant* l'incrément. Si vous utilisez le préfixe opérateur <code>++a</code> le résultat de l'opération est la valeur de la variable <code>a</code> *après* l'incrément. Il en va de même pour l'opérateur <code>--</code> de décrémentation."
@@ -7741,41 +7675,7 @@ msgid "Note: it may be not obvious at first, but notice that <code>=</code> is a
 msgstr "Note : ce n'est peut-être pas évident au début, mais remarquez que <code>=</code> est un *opérateur* et non une instruction. Cela signifie qu'il peut être utilisé au milieu d'une autre expression ! Le résultat de <code>=<</code> est la valeur attribuée à la valeur de droite. Exemple :"
 
 #. type: Source code
-#: ../E/expr.txt:66
-#, no-wrap
-msgid ""
-" int    i = 12 + 3;      // i == 15\n"
-" int    i = 2 - 5;       // i == -3\n"
-" \n"
-" float  f = 3.01 * 10;   // f == 30.1\n"
-" \n"
-" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
-" float  f = 5 / 3;       // f == 1.67\n"
-" float  f = 5 / 0;       // returns an error (division by zero)\n"
-" \n"
-" int    i = 13 % 5;      // i == 3\n"
-" int    i = -8 % 3;      // i == -2\n"
-" \n"
-" float  f = sin(90) * i; // f == -2.0\n"
-" "
-msgstr ""
-" int    i = 12 + 3;      // i == 15\n"
-" int    i = 2 - 5;       // i == -3\n"
-" \n"
-" float  f = 3.01 * 10;   // f == 30.1\n"
-" \n"
-" int    i = 5 / 3;       // i == 1 ( conversion automatique en int)\n"
-" float  f = 5 / 3;       // f == 1.67\n"
-" float  f = 5 / 0;       // retourne une erreur (division par zéro)\n"
-" \n"
-" int    i = 13 % 5;      // i == 3\n"
-" int    i = -8 % 3;      // i == -2\n"
-" \n"
-" float  f = sin(90) * i; // f == -2.0\n"
-" "
-
-#. type: Source code
-#: ../E/expr.txt:108
+#: ../E/expr.txt:109
 #, no-wrap
 msgid ""
 " float pi = 3.14;\n"
@@ -7787,7 +7687,7 @@ msgstr ""
 " message(\"\"+pi);\t//fonctionne"
 
 #. type: Source code
-#: ../E/expr.txt:189
+#: ../E/expr.txt:190
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -7799,7 +7699,7 @@ msgstr ""
 " // ici, b contient 2 et a contient 3"
 
 #. type: Source code
-#: ../E/expr.txt:193
+#: ../E/expr.txt:194
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -7811,25 +7711,25 @@ msgstr ""
 " // ici, b contient 3 et a contient 3"
 
 #. type: \b; header
-#: ../E/expr.txt:137
+#: ../E/expr.txt:138
 #, no-wrap
 msgid "Logical operators"
 msgstr "Opérateurs logiques"
 
 #. type: Plain text
-#: ../E/expr.txt:138
+#: ../E/expr.txt:139
 #, no-wrap
 msgid "Logical operators work with values of type <a cbot|bool>bool</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr "Les opérateurs logiques travaillent avec des valeurs de type booléennes <a cbot|bool>bool</a> et retournent toujours un <a cbot|bool>bool</a>. Elles sont principalement utilisées dans des <a cbot|cond>conditions</a>."
 
 #. type: \b; header
-#: ../E/expr.txt:150
+#: ../E/expr.txt:151
 #, no-wrap
 msgid "Ternary operator"
 msgstr "Opérateur ternaire"
 
 #. type: Plain text
-#: ../E/expr.txt:151
+#: ../E/expr.txt:152
 #, no-wrap
 msgid ""
 "The ternary operator is nothing more than a syntax sugar. It is also known as \"inline if\". It might be confusing at first, because its syntax is a little more complicated than other operators. It can be described as follows:\n"
@@ -7841,19 +7741,19 @@ msgstr ""
 "Les parenthèses ne sont pas nécessaires."
 
 #. type: Plain text
-#: ../E/expr.txt:155
+#: ../E/expr.txt:156
 #, no-wrap
 msgid "Firstly, the condition is valued and then the first result is returned if the condition is true, otherwise the second result is returned."
 msgstr "Tout d'abord, la condition est évaluée, puis le premier résultat est retourné si la condition est vraie, sinon le second résultat est retourné."
 
 #. type: \t; header
-#: ../E/expr.txt:157 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
+#: ../E/expr.txt:158 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
 #, no-wrap
 msgid "Example"
 msgstr "Exemple"
 
 #. type: Source code
-#: ../E/expr.txt:158
+#: ../E/expr.txt:159
 #, no-wrap
 msgid "<c/>float c = ((3.0 > 2.0) ? 10.0 : -10.0); // c == 10.0<n/>"
 msgstr "<c/>float c = ((3.0 > 2.0) ? 10.0 : -10.0); // c == 10.0<n/>"
@@ -7865,19 +7765,19 @@ msgid "A condition is a special <a cbot|expr>expression</a> that returns a <a cb
 msgstr "Une condition est une <a cbot|expr>expression</a> spéciale  qui retourne une valeur <a cbot|bool>booléenne</a>, qui peut être soit <code><a cbot|true>vraie (true)</a></code> soit <code><a cbot|false>fausse (false)</a></code>. Avec une condition, vous pouvez choisir par exemple si les instructions dans une boucle <code><a cbot|while>while</a></code> doivent être répétées à nouveau, ou si l'instruction dans un bloc <code><a cbot|if>if</a></code> doit être exécutée."
 
 #. type: \b; header
-#: ../E/expr.txt:112
+#: ../E/expr.txt:113
 #, no-wrap
 msgid "Comparison operators"
 msgstr "Opérateurs de comparaison"
 
 #. type: Plain text
-#: ../E/expr.txt:113
+#: ../E/expr.txt:114
 #, no-wrap
 msgid "Comparison operators work with values of type <a cbot|bool>float</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr "Les opérateurs de comparaison travaillent avec des valeurs de type <a cbot|bool>float</a> et retournent toujours un <a cbot|bool>booléen (bool)</a>. Ils sont principalement utilisés dans les <a cbot|cond>conditions</a>."
 
 #. type: Plain text
-#: ../E/expr.txt:141
+#: ../E/expr.txt:142
 #, no-wrap
 msgid ""
 "<code>!a      </code>not <code>a</code>\n"
@@ -7889,7 +7789,7 @@ msgstr ""
 "<code>a || b  </code>// <code>a</code> OU <code>b</code>"
 
 #. type: Plain text
-#: ../E/expr.txt:146
+#: ../E/expr.txt:147
 #, no-wrap
 msgid ""
 "<code>!false        </code>returns true\n"
@@ -7901,19 +7801,19 @@ msgstr ""
 "<code>true || false </code>// retourne vrai (true)"
 
 #. type: \b; header
-#: ../E/expr.txt:160
+#: ../E/expr.txt:161
 #, no-wrap
 msgid "Bitwise operators"
 msgstr "Opérateurs bits à bits"
 
 #. type: Plain text
-#: ../E/expr.txt:161
+#: ../E/expr.txt:162
 #, no-wrap
 msgid "Bitwise operators are similar to the logical operator, because they are operating on bits (which can be only 0 or 1, conditions can have a value only of false or true). So in theory, they should be working with basically any type of variable, because each value in the computer must be stored as a sequence of bits."
 msgstr "Les opérateurs bits à bits sont similaires aux opérateurs logiques, parce qu'ils opèrent sur des bits (qui peuvent être seulement 0 ou 1, les conditions peuvent valoir seulement une valeur faux ou vrai). Donc, en théorie, ils devraient fonctionner avec n'importe quel type de variable, parce que chaque valeur dans l'ordinateur doit être stockée sous la forme d'une séquence de bits."
 
 #. type: Plain text
-#: ../E/expr.txt:164
+#: ../E/expr.txt:165
 #, no-wrap
 msgid ""
 "<code>a & b  </code><code>a</code> AND <code>b</code>\n"
@@ -7929,7 +7829,7 @@ msgstr ""
 "<code>a << b  </code>décale les bits of <code>a</code> <code>b</code>  fois vers la gauche"
 
 #. type: Plain text
-#: ../E/expr.txt:171
+#: ../E/expr.txt:172
 #, no-wrap
 msgid ""
 "<code>2 & 1         </code>returns 0\n"
@@ -9502,4 +9402,80 @@ msgid ""
 " {\n"
 "     factory(WheeledGrabber, \"program/say-foo.cbot\");\n"
 " }"
+msgstr ""
+
+#. type: Plain text
+#: ../E/expr.txt:54
+#, no-wrap
+msgid ""
+"<code>+</code>  addition\n"
+"<code>-</code>  subtraction\n"
+"<code>*</code>  multiplication\n"
+"<code>/</code>  division\n"
+"<code>%</code>  remainder of the division (works for <code><a cbot|int>int</a></code> as well as <code><a cbot|float>float</a></code>)"
+msgstr ""
+
+#. type: Source code
+#: ../E/expr.txt:66
+#, no-wrap
+msgid ""
+" int    i = 12 + 3;      // i == 15\n"
+" int    i = 2 - 5;       // i == -3\n"
+" \n"
+" float  f = 3.01 * 10;   // f == 30.1\n"
+" \n"
+" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
+" float  f = 5 / 3;       // f == 1.67\n"
+" float  f = 5 / 0;       // returns an error (division by zero)\n"
+" \n"
+" int    i = 13 % 5;      // i == 3\n"
+" int    i = -8 % 3;      // i == -2\n"
+" float  f = -4.5 % 2.75; // f == -1.75\n"
+" \n"
+" float  f = sin(90) * i; // f == -2.0\n"
+" "
+msgstr ""
+
+#. type: Plain text
+#: ../E/expr.txt:91
+#, no-wrap
+msgid ""
+"<code>+=</code>  addition\n"
+"<code>-=</code>  subtraction\n"
+"<code>*=</code>  multiplication\n"
+"<code>/=</code>  division\n"
+"<code>%=</code>  remainder of the division"
+msgstr ""
+
+#. type: Plain text
+#: ../E/object.txt:4
+#, no-wrap
+msgid ""
+"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
+"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
+"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
+"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
+"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
+"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
+"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
+"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
+"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
+"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
+"<code>object object.energyCell   </code>Power cell on the bot\n"
+"<code>object object.load         </code>Object carried by the bot\n"
+"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
+"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object\n"
+"<code><a cbot|bool>bool</a>   object.dead         </code>Is the object dead?"
+msgstr ""
+
+#. type: Source code
+#: ../E/object.txt:67
+#, no-wrap
+msgid "<code>dead</code>"
+msgstr ""
+
+#. type: Plain text
+#: ../E/object.txt:68
+#, no-wrap
+msgid "True if the object was recently killed (while the death animation is playing). Note that accessing this property or any other property after the death animation finishes will cause an error that stops the program."
 msgstr ""

--- a/help/cbot/po/fr.po
+++ b/help/cbot/po/fr.po
@@ -54,13 +54,13 @@ msgid "Time in seconds."
 msgstr "Temps en secondes."
 
 #. type: \t; header
-#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:198 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:83 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
+#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:197 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:79 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
 #, no-wrap
 msgid "See also"
 msgstr "Voir aussi"
 
 #. type: Plain text
-#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:199 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:84 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
+#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:198 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:80 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
 #, no-wrap
 msgid "<a cbot>Programming</a>, <a cbot|type>types</a> and <a cbot|category>categories</a>."
 msgstr "<a cbot>Programmation</a>, <a cbot|type>types</a> et <a cbot|category>catégories</a>."
@@ -616,7 +616,7 @@ msgid "Conditions"
 msgstr "Les conditions"
 
 #. type: Plain text
-#: ../E/expr.txt:117
+#: ../E/expr.txt:116
 #, no-wrap
 msgid ""
 "<code>a == b  </code><code>a</code> equals <code>b</code>\n"
@@ -634,7 +634,7 @@ msgstr ""
 "<code>a >= b  </code><code>a</code> plus grand ou égal à <code>b</code>"
 
 #. type: Plain text
-#: ../E/expr.txt:125
+#: ../E/expr.txt:124
 #, no-wrap
 msgid ""
 "<code>12 == 12  </code>returns true\n"
@@ -652,13 +652,13 @@ msgstr ""
 "<code>12 >= 12  </code>retourne vrai"
 
 #. type: Plain text
-#: ../E/expr.txt:133
+#: ../E/expr.txt:132
 #, no-wrap
 msgid "Be careful not to confuse the equality comparison <code>==</code> with the assignment of a <a cbot|var>variable</a> <code>=</code>."
 msgstr "Il faut faire très attention à ne pas confondre la comparaison d'égalité <code>==</code> avec l'affectation d'une <a cbot|var>variable</a> <code>=</code>."
 
 #. type: Plain text
-#: ../E/expr.txt:135
+#: ../E/expr.txt:134
 #, no-wrap
 msgid ""
 "<code>a == b</code> is an expression that compares <code>a</code> with <code>b</code>.\n"
@@ -1263,13 +1263,29 @@ msgid "Expressions"
 msgstr "Les expressions"
 
 #. type: Plain text
-#: ../E/expr.txt:87
+#: ../E/expr.txt:86
 #, no-wrap
 msgid "is equivalent to"
 msgstr "est équivalent à"
 
 #. type: Plain text
-#: ../E/expr.txt:179
+#: ../E/expr.txt:90
+#, no-wrap
+msgid ""
+"<code>+=</code>  addition\n"
+"<code>-=</code>  subtraction\n"
+"<code>*=</code>  multiplication\n"
+"<code>/=</code>  division\n"
+"<code>%=</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
+msgstr ""
+"<code>+=</code>  addition\n"
+"<code>-=</code>  soustraction\n"
+"<code>*=</code>  multiplication\n"
+"<code>/=</code>  division\n"
+"<code>%=</code>  reste de la division (seulement pour le type <code><a cbot|int>int</a></code>)"
+
+#. type: Plain text
+#: ../E/expr.txt:178
 #, no-wrap
 msgid "The operators <code>++</code> and <code>--</code> allow you to increment (++) or to decrement (--) a variable in very compact and efficient manner."
 msgstr "Les opérateurs <code>++</code> et <code>--</code> permettent d'incrémenter (++) ou décrémenter (--) une variable de manière particulièrement compacte et efficace."
@@ -2410,67 +2426,67 @@ msgid "Type <code>object</code>"
 msgstr "Type <code>object</code>"
 
 #. type: Source code
-#: ../E/object.txt:22
+#: ../E/object.txt:21
 #, no-wrap
 msgid "<code>category</code>"
 msgstr "<code>category</code>"
 
 #. type: Source code
-#: ../E/object.txt:25
+#: ../E/object.txt:24
 #, no-wrap
 msgid "<code>position</code>"
 msgstr "<code>position</code>"
 
 #. type: Plain text
-#: ../E/object.txt:26
+#: ../E/object.txt:25
 #, no-wrap
 msgid "Position of the object on the planet, in meters. The coordinates <code>x</code> and <code>y</code> correspond to the location on a map, the <code>z</code> coordinate corresponds to the altitude above (respectively below) sea level. "
 msgstr "Position de l'objet sur la planète, en mètres. Les coordonnées <code>x</code> et <code>y</code> correspondent à la position à plat, alors que <code>z</code> correspond à l'élévation absolue par rapport au niveau de la mer."
 
 #. type: Source code
-#: ../E/object.txt:28
+#: ../E/object.txt:27
 #, no-wrap
 msgid "<code>orientation</code>"
 msgstr "<code>orientation</code>"
 
 #. type: Plain text
-#: ../E/object.txt:29
+#: ../E/object.txt:28
 #, no-wrap
 msgid "Orientation of the object, in degrees. The orientation tells you what direction the object is facing. An orientation of <code>0</code> corresponds to an object facing eastwards, thus following the positive <code>x</code> axis. The orientation is measured counterclockwise. "
 msgstr "Orientation de l'objet, en degrés. Une orientation de <code>0</code> correspond à un objet tourné vers l'est, donc vers l'axe <code>x</code> positif. Le sens de l'orientation est anti-horaire."
 
 #. type: Source code
-#: ../E/object.txt:31
+#: ../E/object.txt:30
 #, no-wrap
 msgid "<code>pitch</code>"
 msgstr "<code>pitch</code>"
 
 #. type: Plain text
-#: ../E/object.txt:32
+#: ../E/object.txt:31
 #, no-wrap
 msgid "Forward/backward angle of the robot. A pitch of <code>0</code> means that the bot is standing on flat ground. A positive inclination means that it is facing upwards, a negative inclination means that it is facing downwards. "
 msgstr "Inclinaison avant/arrière de l'objet, en degrés. Une valeur positive indique que le robot monte."
 
 #. type: Source code
-#: ../E/object.txt:34
+#: ../E/object.txt:33
 #, no-wrap
 msgid "<code>roll</code>"
 msgstr "<code>roll</code>"
 
 #. type: Plain text
-#: ../E/object.txt:35
+#: ../E/object.txt:34
 #, no-wrap
 msgid "Left/right angle of the bot, in degrees. A positive value means that the bot is leaning to the left side, a negative value means that it is leaning to the right side. "
 msgstr "Inclinaison latérale de l'objet, en degrés. Une valeur positive indique que le robot penche à gauche."
 
 #. type: Source code
-#: ../E/object.txt:37
+#: ../E/object.txt:36
 #, no-wrap
 msgid "<code>energyLevel</code>"
 msgstr "<code>energyLevel</code>"
 
 #. type: Plain text
-#: ../E/object.txt:38
+#: ../E/object.txt:37
 #, no-wrap
 msgid "Energy level, between 0 and 1. A normal <a object|power>power cell</a> that is fully charged returns the value <code>1</code>. A <a object|atomic>nuclear power cell</a> never returns a value higher than 1, it just lasts longer. Attention: The energy level of a bot is always zero, because the energy is not contained in the bot, but in the power cell. To know the energy level of the power cell of a bot, you must write <code>energyCell.energyLevel</code>. "
 msgstr ""
@@ -2478,13 +2494,13 @@ msgstr ""
 "Notez que le niveau d'énergie d'un robot est toujours nul. En effet, l'énergie est contenue dans la pile ou la batterie qui est placée à l'arrière du robot, et non dans le robot lui-même. Il faut donc écrire <code>energyCell.energyLevel</code> pour connaître l'énergie à disposition."
 
 #. type: Source code
-#: ../E/object.txt:40
+#: ../E/object.txt:39
 #, no-wrap
 msgid "<code>shieldLevel</code>"
 msgstr "<code>shieldLevel</code>"
 
 #. type: Plain text
-#: ../E/object.txt:41
+#: ../E/object.txt:40
 #, no-wrap
 msgid ""
 "Shield level of a robot or building. A level <code>1</code> indicates that the shield is still perfect. Every time that the bot or building gets a bullet or collides with another object, the shield level decreases. When the level reaches <code>0</code>, the next bullet or collision will destroy the bot or building. \n"
@@ -2494,49 +2510,49 @@ msgstr ""
 "Les robots peuvent régénérer leurs boucliers sur le <a object|repair>centre de réparation</a>. Le bouclier d'un bâtiment est régénéré s'il se trouve dans la sphère protectrice du <a object|botshld>robot bouclier</a>."
 
 #. type: Source code
-#: ../E/object.txt:44
+#: ../E/object.txt:43
 #, no-wrap
 msgid "<code>temperature</code>"
 msgstr "<code>temperature</code>"
 
 #. type: Plain text
-#: ../E/object.txt:45
+#: ../E/object.txt:44
 #, no-wrap
 msgid "Temperature of the jet of <a object|botgj>winged bots</a>. <code>0</code> corresponds to a cold jet. When used, the temperature increases progressively. When it reaches the value <code>1</code>, the jet is overheated and stops working, until it cooled down a little. "
 msgstr "Température du réacteur pour les <a object|botgj>robots volants</a>. <code>0</code> correspond à un réacteur froid et <code>1</code> à un réacteur bouillant, provisoirement hors d'usage."
 
 #. type: Source code
-#: ../E/object.txt:47
+#: ../E/object.txt:46
 #, no-wrap
 msgid "<code>altitude</code>"
 msgstr "<code>altitude</code>"
 
 #. type: Plain text
-#: ../E/object.txt:48
+#: ../E/object.txt:47
 #, no-wrap
 msgid "The <code>z</code> coordinate of the position indicates the altitude above sea level, whereas the <code>altitude</code> indicates the height above ground. This value is meaningful only for <a object|botgj>winged bots</a> and for <a object|wasp>wasps</a>. For all other objects, this value is zero. "
 msgstr "Contrairement à la position <code>z</code> qui est absolue, l'altitude est relative au niveau du sol. L'altitude n'a de sens que pour les <a object|botgj>robots volants</a> et la <a object|wasp>guêpe</a>. Pour tous les autres robots ou pour les bâtiments, cette valeur est nulle."
 
 #. type: Source code
-#: ../E/object.txt:50
+#: ../E/object.txt:49
 #, no-wrap
 msgid "<code>lifeTime</code>"
 msgstr "<code>lifeTime</code>"
 
 #. type: Plain text
-#: ../E/object.txt:51
+#: ../E/object.txt:50
 #, no-wrap
 msgid "The age of the object in seconds since it's creation."
 msgstr "Donne l'âge de l'objet, en secondes."
 
 #. type: Source code
-#: ../E/object.txt:53
+#: ../E/object.txt:52
 #, no-wrap
 msgid "<code>energyCell</code>"
 msgstr "<code>energyCell</code>"
 
 #. type: Plain text
-#: ../E/object.txt:54
+#: ../E/object.txt:53
 #, no-wrap
 msgid ""
 "This information is special, because it returns the information about another object, in this case the power pack. This means that energyCell contains all the characteristics of a normal object, for example <code>category</code> (PowerCell or NuclearCell), <code>position</code> (the position of the cell), etc.\n"
@@ -2548,31 +2564,31 @@ msgstr ""
 "Si le robot n'a pas de pile ni de batterie, <code>energyCell</code> vaut <code>null</code>."
 
 #. type: Source code
-#: ../E/object.txt:58
+#: ../E/object.txt:57
 #, no-wrap
 msgid "<code>load</code>"
 msgstr "<code>load</code>"
 
 #. type: Plain text
-#: ../E/object.txt:59
+#: ../E/object.txt:58
 #, no-wrap
 msgid "This information also returns the description of a whole object: the description of the object carried by a <a object|botgr>grabber</a>. If it carries nothing, <code>load</code> returns <code>null</code>."
 msgstr "Cette information est spéciale, comme la précédente. Elle contient les caractéristiques de l'objet transporté par le <a object|botgr>robot préhenseur</a>. S'il ne transporte rien, <code>load</code> vaut <code>null</code>."
 
 #. type: \t; header, \b; header
-#: ../E/expr.txt:100 ../E/expr.txt:124 ../E/expr.txt:146 ../E/expr.txt:171 ../E/expr.txt:188 ../E/factory.txt:21 ../E/object.txt:70
+#: ../E/expr.txt:99 ../E/expr.txt:123 ../E/expr.txt:145 ../E/expr.txt:170 ../E/expr.txt:187 ../E/factory.txt:21 ../E/object.txt:66
 #, no-wrap
 msgid "Examples"
 msgstr "Examples"
 
 #. type: Plain text
-#: ../E/object.txt:71
+#: ../E/object.txt:67
 #, no-wrap
 msgid "The type <code>object</code> returns the special value <code><a cbot|null>null</a></code> when the object does not exist. For example:"
 msgstr "Le type <code>object</code> prend la valeur particulière <code><a cbot|null>null</a></code> lorsque l'objet n'existe pas. Par exemple:"
 
 #. type: Source code
-#: ../E/object.txt:73
+#: ../E/object.txt:69
 #, no-wrap
 msgid ""
 "\tobject a;\n"
@@ -3197,7 +3213,7 @@ msgid "Returns the first object found that corresponds to the specified category
 msgstr "Objet trouvé le plus proche. La valeur <code><a cbot|null>null</a></code> indique que rien n'a été trouvé."
 
 #. type: \t; header
-#: ../E/expr.txt:132 ../E/radar.txt:68
+#: ../E/expr.txt:131 ../E/radar.txt:68
 #, no-wrap
 msgid "Remark"
 msgstr "Remarque"
@@ -6480,37 +6496,71 @@ msgid "Use this type for variables that contain the characteristics of an object
 msgstr "Utilisez ce type pour les variables qui contiennent les caractéristiques d'un objet, que ce soit un robot, un bâtiment, une matière première, un ennemi, etc. Voici toutes les propriétés d'un objet : "
 
 #. type: Plain text
-#: ../E/object.txt:20
+#: ../E/object.txt:4
+#, no-wrap
+msgid ""
+"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
+"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
+"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
+"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
+"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
+"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
+"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
+"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
+"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
+"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
+"<code>object object.energyCell   </code>Power cell on the bot\n"
+"<code>object object.load         </code>Object carried by the bot\n"
+"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
+"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object"
+msgstr ""
+"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Catégorie</a> de l'objet\n"
+"<code><a cbot|point>point</a>  object.position     </code>Position de l'objet (x,y,z)\n"
+"<code><a cbot|float>float</a>  object.orientation  </code>Orientation de l'objet (0..360)\n"
+"<code><a cbot|float>float</a>  object.pitch        </code>Angle de bascule de l'objet\n"
+"<code><a cbot|float>float</a>  object.roll         </code>Angle d'inclinaison de l'object \n"
+"<code><a cbot|float>float</a>  object.energyLevel  </code>Niveau d'énergie (0..1)\n"
+"<code><a cbot|float>float</a>  object.shieldLevel  </code>Niveau de bouclier (0..1)\n"
+"<code><a cbot|float>float</a>  object.temperature  </code>Chaleur du jet (0..1)\n"
+"<code><a cbot|float>float</a>  object.altitude     </code>Altitude par rapport au sol\n"
+"<code><a cbot|float>float</a>  object.lifeTime     </code>Durée de vie de l'objet\n"
+"<code>object object.energyCell   </code>batterie ou pile du robot\n"
+"<code>object object.load         </code>Objet transporté par le préhenseur\n"
+"<code><a cbot|int>int</a>    object.team         </code>Équipe de l'objet (Voir <a battles>batailles de code</a>)\n"
+"<code><a cbot|point>point</a>  object.velocity     </code>Vitesse de l'objet"
+
+#. type: Plain text
+#: ../E/object.txt:19
 #, no-wrap
 msgid "Also, some objects have additional methods (instructions). See them in <a cbot>the main list</a> in the <c/>\"Instructions specific for some objects\" section."
 msgstr "De plus, certains objets ont des méthodes (instructions) supplémentaires. Se reporter à la <a cbot>la liste principale</a> dans la section <c/>\"Instructions spécifiques pour certains objets\"."
 
 #. type: Plain text
-#: ../E/object.txt:23
+#: ../E/object.txt:22
 #, no-wrap
 msgid "The <n/><a cbot|category>category</a> of an object allows you to know what it is, f. ex. what kind of bot, building, enemy, etc."
 msgstr "<n/>La <a cbot|category>catégorie</a> d'un objet vous permet de savoir de quoi il s'agit, par exemple de quel type de robot, bâtiment, ennemi, etc."
 
 #. type: Source code
-#: ../E/object.txt:61
+#: ../E/object.txt:60
 #, no-wrap
 msgid "<code>team</code>"
 msgstr "<code>team</code>"
 
 #. type: Plain text
-#: ../E/object.txt:62
+#: ../E/object.txt:61
 #, no-wrap
 msgid "The bot's team. Used in <a battles>code battles</a>. If the object has no team assigned (e.g. in no team-based levels, the object being a resource), this is equal to <code>0</code>."
 msgstr "L'équipe du robot. Utilisé dans <a battles>bataille de codes</a>. Si l'objet n'a pas d'équipe affectée (par exemple, dans les niveau non basé sur les équipes ou l'objet étant une ressource), ceci est égal à <code>0</code>."
 
 #. type: Source code
-#: ../E/object.txt:64
+#: ../E/object.txt:63
 #, no-wrap
 msgid "<code>velocity</code>"
 msgstr "<code>velocity</code>"
 
 #. type: Plain text
-#: ../E/object.txt:65
+#: ../E/object.txt:64
 #, no-wrap
 msgid "Current velocity of the object. Should be treated as a three-dimensional vector."
 msgstr "Vitesse actuelle de l'objet, dans chacun des axes x,y et z. Doit être traité comme un vecteur tridimensionnel."
@@ -7524,10 +7574,26 @@ msgid "Binary operators below are working with fundamental number types (<code><
 msgstr "Les opérateurs binaires ci-dessous fonctionnent avec les types de nombres fondamentaux (<code><a cbot|int>int</a></code>, <code><a cbot|float>float</a></code>)."
 
 #. type: \t; header
-#: ../E/expr.txt:53 ../E/expr.txt:90 ../E/expr.txt:116 ../E/expr.txt:141 ../E/expr.txt:164
+#: ../E/expr.txt:53 ../E/expr.txt:89 ../E/expr.txt:115 ../E/expr.txt:140 ../E/expr.txt:163
 #, no-wrap
 msgid "List"
 msgstr "Listes"
+
+#. type: Plain text
+#: ../E/expr.txt:54
+#, no-wrap
+msgid ""
+"<code>+</code>  addition\n"
+"<code>-</code>  subtraction\n"
+"<code>*</code>  multiplication\n"
+"<code>/</code>  division\n"
+"<code>%</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
+msgstr ""
+"<code>+</code>  addition\n"
+"<code>-</code>   soustraction\n"
+"<code>*</code>  multiplication\n"
+"<code>/</code>   division\n"
+"<code>%</code>  reste de la division ( seulement pour le type <code><a cbot|int>int</a></code>)"
 
 #. type: \t; header
 #: ../E/expr.txt:60
@@ -7556,49 +7622,49 @@ msgid "Real life examples"
 msgstr "Exemples dans la vie réelle"
 
 #. type: \t; header
-#: ../E/expr.txt:82
+#: ../E/expr.txt:81
 #, no-wrap
 msgid "Compound assignment operators"
 msgstr "Opérateurs d'assignation composée"
 
 #. type: Plain text
-#: ../E/expr.txt:83
+#: ../E/expr.txt:82
 #, no-wrap
 msgid "Besides the <code>=</code> operator for variable assignment there are several compound-assignment operators."
 msgstr "En plus de l'opérateur <code>=</code> pour l'assignation de variables, il existe plusieurs opérateurs d'assignation composée."
 
 #. type: Plain text
-#: ../E/expr.txt:85
+#: ../E/expr.txt:84
 #, no-wrap
 msgid "The compound-assignment operators combine the <code>=</code> assignment operator with another binary operator such as <code>+</code> or <code>-</code>. Compound-assignment operators perform the operation specified by the additional operator and then assign the result to the left operand. For example, a compound-assignment expression such as"
 msgstr "Les opérateurs d'assignation composée combinent l'opérateur assignation <code>=</code> avec un autre opérateur binaire tel que <code>+</code> ou <code>-</code>. Les opérateurs d'assignation composée effectuent l'opération spécifiée par l'opérateur supplémentaire et affectent ensuite le résultat à l'opérande de gauche. Par exemple, une expression d'affectation composée telle que"
 
 #. type: Source code
-#: ../E/expr.txt:86
+#: ../E/expr.txt:85
 #, no-wrap
 msgid "<code>lvalue += expression</code>"
 msgstr "<code>lvalue += expression</code>"
 
 #. type: Source code
-#: ../E/expr.txt:88
+#: ../E/expr.txt:87
 #, no-wrap
 msgid "<code>lvalue = lvalue + expression</code>"
 msgstr "<code>lvalue = lvalue + expression</code>"
 
 #. type: \b; header
-#: ../E/expr.txt:97
+#: ../E/expr.txt:96
 #, no-wrap
 msgid "String concatenation"
 msgstr "Concaténation de chaînes (string)"
 
 #. type: Plain text
-#: ../E/expr.txt:98
+#: ../E/expr.txt:97
 #, no-wrap
 msgid "If at least one of the values used with the <code>+</code> operator is a <a cbot|string>string</a>, then the operation of concatenation is performed. The result of the operator is then a string, which is created by joining end-to-end the string and the other value. If the other value is not a string, then it is converted to string beforehand."
 msgstr "Si au moins une des valeurs utilisées avec l'opérateur <code>+</code> est un <a cbot|string>string</a>, l'opération de concaténation est effectuée. Le résultat de l'opérateur est alors une chaîne, qui est créée en joignant la chaîne de bout en bout et l'autre valeur. Si l'autre valeur n'est pas une chaîne de caractères, elle est convertie en chaîne au préalable."
 
 #. type: Source code
-#: ../E/expr.txt:102
+#: ../E/expr.txt:101
 #, no-wrap
 msgid ""
 "\tstring s = \"a\" + \"bc\";  // returns \"abc\"\n"
@@ -7612,43 +7678,43 @@ msgstr ""
 "\tstring s = \"a\" + true;    // retourne \"atrue\""
 
 #. type: Plain text
-#: ../E/expr.txt:107
+#: ../E/expr.txt:106
 #, no-wrap
 msgid "Tip: the properties of the concatenation <code>+</code> operator is useful with the <a cbot|message>message();</a> function, because it does not work with other types than string. An empty string can be used together with a value in order to create a string, which actually can be passed to the <a cbot|message>message();</a> function:"
 msgstr "Astuce : les propriétés de l'opérateur concaténation <code>+</code> sont utiles avec la fonction <a cbot|message>message();</a>, car elle ne fonctionne pas avec d'autres types que la chaîne. Une chaîne vide peut être utilisée avec une valeur pour créer une chaîne, qui peut être passée à la fonction <a cbot|message>message();</a> :"
 
 #. type: \b; header
-#: ../E/expr.txt:178
+#: ../E/expr.txt:177
 #, no-wrap
 msgid "Prefix and postfix increment- and decrement operators"
 msgstr "Opérateurs préfixés et postfixés d'incrémentation et de décrémentation"
 
 #. type: Plain text
-#: ../E/expr.txt:181
+#: ../E/expr.txt:180
 #, no-wrap
 msgid "For example to increment the variable <code>a</code> you can write"
 msgstr "Par exemple pour pré-incrémenter la variable <code>a</code> vous pouvez écrire"
 
 #. type: Source code
-#: ../E/expr.txt:182
+#: ../E/expr.txt:181
 #, no-wrap
 msgid "<c/>a++;<n/>"
 msgstr "<c/>a++;<n/>"
 
 #. type: Plain text
-#: ../E/expr.txt:183
+#: ../E/expr.txt:182
 #, no-wrap
 msgid "instead of"
 msgstr "au lieu de"
 
 #. type: Source code
-#: ../E/expr.txt:184
+#: ../E/expr.txt:183
 #, no-wrap
 msgid "<c/>a = a + 1;<n/>"
 msgstr "<c/>a = a + 1;<n/>"
 
 #. type: Plain text
-#: ../E/expr.txt:186
+#: ../E/expr.txt:185
 #, no-wrap
 msgid "The result of the operation <code>a++</code> is the value of the variable <code>a</code> *before* the increment. If you use the prefix operator <code>++a</code> the result of the operation is the value of the variable <code>a</code> *after* the increment. The same holds for the <code>--</code> decrement operator."
 msgstr "Le résultat de l'opération <code>a++</code> est la valeur de la variable <code>a</code> *avant* l'incrément. Si vous utilisez le préfixe opérateur <code>++a</code> le résultat de l'opération est la valeur de la variable <code>a</code> *après* l'incrément. Il en va de même pour l'opérateur <code>--</code> de décrémentation."
@@ -7675,7 +7741,41 @@ msgid "Note: it may be not obvious at first, but notice that <code>=</code> is a
 msgstr "Note : ce n'est peut-être pas évident au début, mais remarquez que <code>=</code> est un *opérateur* et non une instruction. Cela signifie qu'il peut être utilisé au milieu d'une autre expression ! Le résultat de <code>=<</code> est la valeur attribuée à la valeur de droite. Exemple :"
 
 #. type: Source code
-#: ../E/expr.txt:109
+#: ../E/expr.txt:66
+#, no-wrap
+msgid ""
+" int    i = 12 + 3;      // i == 15\n"
+" int    i = 2 - 5;       // i == -3\n"
+" \n"
+" float  f = 3.01 * 10;   // f == 30.1\n"
+" \n"
+" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
+" float  f = 5 / 3;       // f == 1.67\n"
+" float  f = 5 / 0;       // returns an error (division by zero)\n"
+" \n"
+" int    i = 13 % 5;      // i == 3\n"
+" int    i = -8 % 3;      // i == -2\n"
+" \n"
+" float  f = sin(90) * i; // f == -2.0\n"
+" "
+msgstr ""
+" int    i = 12 + 3;      // i == 15\n"
+" int    i = 2 - 5;       // i == -3\n"
+" \n"
+" float  f = 3.01 * 10;   // f == 30.1\n"
+" \n"
+" int    i = 5 / 3;       // i == 1 ( conversion automatique en int)\n"
+" float  f = 5 / 3;       // f == 1.67\n"
+" float  f = 5 / 0;       // retourne une erreur (division par zéro)\n"
+" \n"
+" int    i = 13 % 5;      // i == 3\n"
+" int    i = -8 % 3;      // i == -2\n"
+" \n"
+" float  f = sin(90) * i; // f == -2.0\n"
+" "
+
+#. type: Source code
+#: ../E/expr.txt:108
 #, no-wrap
 msgid ""
 " float pi = 3.14;\n"
@@ -7687,7 +7787,7 @@ msgstr ""
 " message(\"\"+pi);\t//fonctionne"
 
 #. type: Source code
-#: ../E/expr.txt:190
+#: ../E/expr.txt:189
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -7699,7 +7799,7 @@ msgstr ""
 " // ici, b contient 2 et a contient 3"
 
 #. type: Source code
-#: ../E/expr.txt:194
+#: ../E/expr.txt:193
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -7711,25 +7811,25 @@ msgstr ""
 " // ici, b contient 3 et a contient 3"
 
 #. type: \b; header
-#: ../E/expr.txt:138
+#: ../E/expr.txt:137
 #, no-wrap
 msgid "Logical operators"
 msgstr "Opérateurs logiques"
 
 #. type: Plain text
-#: ../E/expr.txt:139
+#: ../E/expr.txt:138
 #, no-wrap
 msgid "Logical operators work with values of type <a cbot|bool>bool</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr "Les opérateurs logiques travaillent avec des valeurs de type booléennes <a cbot|bool>bool</a> et retournent toujours un <a cbot|bool>bool</a>. Elles sont principalement utilisées dans des <a cbot|cond>conditions</a>."
 
 #. type: \b; header
-#: ../E/expr.txt:151
+#: ../E/expr.txt:150
 #, no-wrap
 msgid "Ternary operator"
 msgstr "Opérateur ternaire"
 
 #. type: Plain text
-#: ../E/expr.txt:152
+#: ../E/expr.txt:151
 #, no-wrap
 msgid ""
 "The ternary operator is nothing more than a syntax sugar. It is also known as \"inline if\". It might be confusing at first, because its syntax is a little more complicated than other operators. It can be described as follows:\n"
@@ -7741,19 +7841,19 @@ msgstr ""
 "Les parenthèses ne sont pas nécessaires."
 
 #. type: Plain text
-#: ../E/expr.txt:156
+#: ../E/expr.txt:155
 #, no-wrap
 msgid "Firstly, the condition is valued and then the first result is returned if the condition is true, otherwise the second result is returned."
 msgstr "Tout d'abord, la condition est évaluée, puis le premier résultat est retourné si la condition est vraie, sinon le second résultat est retourné."
 
 #. type: \t; header
-#: ../E/expr.txt:158 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
+#: ../E/expr.txt:157 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
 #, no-wrap
 msgid "Example"
 msgstr "Exemple"
 
 #. type: Source code
-#: ../E/expr.txt:159
+#: ../E/expr.txt:158
 #, no-wrap
 msgid "<c/>float c = ((3.0 > 2.0) ? 10.0 : -10.0); // c == 10.0<n/>"
 msgstr "<c/>float c = ((3.0 > 2.0) ? 10.0 : -10.0); // c == 10.0<n/>"
@@ -7765,19 +7865,19 @@ msgid "A condition is a special <a cbot|expr>expression</a> that returns a <a cb
 msgstr "Une condition est une <a cbot|expr>expression</a> spéciale  qui retourne une valeur <a cbot|bool>booléenne</a>, qui peut être soit <code><a cbot|true>vraie (true)</a></code> soit <code><a cbot|false>fausse (false)</a></code>. Avec une condition, vous pouvez choisir par exemple si les instructions dans une boucle <code><a cbot|while>while</a></code> doivent être répétées à nouveau, ou si l'instruction dans un bloc <code><a cbot|if>if</a></code> doit être exécutée."
 
 #. type: \b; header
-#: ../E/expr.txt:113
+#: ../E/expr.txt:112
 #, no-wrap
 msgid "Comparison operators"
 msgstr "Opérateurs de comparaison"
 
 #. type: Plain text
-#: ../E/expr.txt:114
+#: ../E/expr.txt:113
 #, no-wrap
 msgid "Comparison operators work with values of type <a cbot|bool>float</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr "Les opérateurs de comparaison travaillent avec des valeurs de type <a cbot|bool>float</a> et retournent toujours un <a cbot|bool>booléen (bool)</a>. Ils sont principalement utilisés dans les <a cbot|cond>conditions</a>."
 
 #. type: Plain text
-#: ../E/expr.txt:142
+#: ../E/expr.txt:141
 #, no-wrap
 msgid ""
 "<code>!a      </code>not <code>a</code>\n"
@@ -7789,7 +7889,7 @@ msgstr ""
 "<code>a || b  </code>// <code>a</code> OU <code>b</code>"
 
 #. type: Plain text
-#: ../E/expr.txt:147
+#: ../E/expr.txt:146
 #, no-wrap
 msgid ""
 "<code>!false        </code>returns true\n"
@@ -7801,19 +7901,19 @@ msgstr ""
 "<code>true || false </code>// retourne vrai (true)"
 
 #. type: \b; header
-#: ../E/expr.txt:161
+#: ../E/expr.txt:160
 #, no-wrap
 msgid "Bitwise operators"
 msgstr "Opérateurs bits à bits"
 
 #. type: Plain text
-#: ../E/expr.txt:162
+#: ../E/expr.txt:161
 #, no-wrap
 msgid "Bitwise operators are similar to the logical operator, because they are operating on bits (which can be only 0 or 1, conditions can have a value only of false or true). So in theory, they should be working with basically any type of variable, because each value in the computer must be stored as a sequence of bits."
 msgstr "Les opérateurs bits à bits sont similaires aux opérateurs logiques, parce qu'ils opèrent sur des bits (qui peuvent être seulement 0 ou 1, les conditions peuvent valoir seulement une valeur faux ou vrai). Donc, en théorie, ils devraient fonctionner avec n'importe quel type de variable, parce que chaque valeur dans l'ordinateur doit être stockée sous la forme d'une séquence de bits."
 
 #. type: Plain text
-#: ../E/expr.txt:165
+#: ../E/expr.txt:164
 #, no-wrap
 msgid ""
 "<code>a & b  </code><code>a</code> AND <code>b</code>\n"
@@ -7829,7 +7929,7 @@ msgstr ""
 "<code>a << b  </code>décale les bits of <code>a</code> <code>b</code>  fois vers la gauche"
 
 #. type: Plain text
-#: ../E/expr.txt:172
+#: ../E/expr.txt:171
 #, no-wrap
 msgid ""
 "<code>2 & 1         </code>returns 0\n"
@@ -9403,119 +9503,3 @@ msgid ""
 "     factory(WheeledGrabber, \"program/say-foo.cbot\");\n"
 " }"
 msgstr ""
-
-#. type: Plain text
-#: ../E/expr.txt:54
-#, no-wrap
-msgid ""
-"<code>+</code>  addition\n"
-"<code>-</code>  subtraction\n"
-"<code>*</code>  multiplication\n"
-"<code>/</code>  division\n"
-"<code>%</code>  remainder of the division (works for <code><a cbot|int>int</a></code> as well as <code><a cbot|float>float</a></code>)"
-msgstr ""
-"<code>+</code>  addition\n"
-"<code>-</code>   soustraction\n"
-"<code>*</code>  multiplication\n"
-"<code>/</code>   division\n"
-"<code>%</code>  reste de la division (fonctionne pour <code><a cbot|int>int</a></code> ainsi que <code><a cbot|float>float</a></code>)"
-
-#. type: Source code
-#: ../E/expr.txt:66
-#, no-wrap
-msgid ""
-" int    i = 12 + 3;      // i == 15\n"
-" int    i = 2 - 5;       // i == -3\n"
-" \n"
-" float  f = 3.01 * 10;   // f == 30.1\n"
-" \n"
-" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
-" float  f = 5 / 3;       // f == 1.67\n"
-" float  f = 5 / 0;       // returns an error (division by zero)\n"
-" \n"
-" int    i = 13 % 5;      // i == 3\n"
-" int    i = -8 % 3;      // i == -2\n"
-" float  f = -4.5 % 2.75; // f == -1.75\n"
-" \n"
-" float  f = sin(90) * i; // f == -2.0\n"
-" "
-msgstr ""
-" int    i = 12 + 3;      // i == 15\n"
-" int    i = 2 - 5;       // i == -3\n"
-" \n"
-" float  f = 3.01 * 10;   // f == 30.1\n"
-" \n"
-" int    i = 5 / 3;       // i == 1 ( conversion automatique en int)\n"
-" float  f = 5 / 3;       // f == 1.67\n"
-" float  f = 5 / 0;       // retourne une erreur (division par zéro)\n"
-" \n"
-" int    i = 13 % 5;      // i == 3\n"
-" int    i = -8 % 3;      // i == -2\n"
-" float  f = -4.5 % 2.75; // f == -1.75\n"
-" \n"
-" float  f = sin(90) * i; // f == -2.0\n"
-" "
-
-#. type: Plain text
-#: ../E/expr.txt:91
-#, no-wrap
-msgid ""
-"<code>+=</code>  addition\n"
-"<code>-=</code>  subtraction\n"
-"<code>*=</code>  multiplication\n"
-"<code>/=</code>  division\n"
-"<code>%=</code>  remainder of the division"
-msgstr ""
-"<code>+=</code>  addition\n"
-"<code>-=</code>  soustraction\n"
-"<code>*=</code>  multiplication\n"
-"<code>/=</code>  division\n"
-"<code>%=</code>  reste de la division"
-
-#. type: Plain text
-#: ../E/object.txt:4
-#, no-wrap
-msgid ""
-"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
-"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
-"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
-"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
-"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
-"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
-"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
-"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
-"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
-"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
-"<code>object object.energyCell   </code>Power cell on the bot\n"
-"<code>object object.load         </code>Object carried by the bot\n"
-"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
-"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object\n"
-"<code><a cbot|bool>bool</a>   object.dead         </code>Is the object dead?"
-msgstr ""
-"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Catégorie</a> de l'objet\n"
-"<code><a cbot|point>point</a>  object.position     </code>Position de l'objet (x,y,z)\n"
-"<code><a cbot|float>float</a>  object.orientation  </code>Orientation de l'objet (0..360)\n"
-"<code><a cbot|float>float</a>  object.pitch        </code>Angle de bascule de l'objet\n"
-"<code><a cbot|float>float</a>  object.roll         </code>Angle d'inclinaison de l'object \n"
-"<code><a cbot|float>float</a>  object.energyLevel  </code>Niveau d'énergie (0..1)\n"
-"<code><a cbot|float>float</a>  object.shieldLevel  </code>Niveau de bouclier (0..1)\n"
-"<code><a cbot|float>float</a>  object.temperature  </code>Chaleur du jet (0..1)\n"
-"<code><a cbot|float>float</a>  object.altitude     </code>Altitude par rapport au sol\n"
-"<code><a cbot|float>float</a>  object.lifeTime     </code>Durée de vie de l'objet\n"
-"<code>object object.energyCell   </code>batterie ou pile du robot\n"
-"<code>object object.load         </code>Objet transporté par le préhenseur\n"
-"<code><a cbot|int>int</a>    object.team         </code>Équipe de l'objet (Voir <a battles>batailles de code</a>)\n"
-"<code><a cbot|point>point</a>  object.velocity     </code>Vitesse de l'objet\n"
-"<code><a cbot|bool>bool</a>   object.dead         </code>L'objet est-il mort?"
-
-#. type: Source code
-#: ../E/object.txt:67
-#, no-wrap
-msgid "<code>dead</code>"
-msgstr ""
-
-#. type: Plain text
-#: ../E/object.txt:68
-#, no-wrap
-msgid "True if the object was recently killed (while the death animation is playing). Note that accessing this property or any other property after the death animation finishes will cause an error that stops the program."
-msgstr "True si l'objet a été tué récemment (pendant la lecture de l'animation de mort). Notez que l'accès à cette propriété ou à toute autre propriété après la fin de l'animation de mort provoquera une erreur qui arrêtera le programme."

--- a/help/cbot/po/pl.po
+++ b/help/cbot/po/pl.po
@@ -53,13 +53,13 @@ msgid "Time in seconds."
 msgstr "Czas w sekundach."
 
 #. type: \t; header
-#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:197 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:79 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
+#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:198 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:83 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
 #, no-wrap
 msgid "See also"
 msgstr "Zobacz również"
 
 #. type: Plain text
-#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:198 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:80 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
+#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:199 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:84 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
 #, no-wrap
 msgid "<a cbot>Programming</a>, <a cbot|type>types</a> and <a cbot|category>categories</a>."
 msgstr "<a cbot>Programowanie</a>, <a cbot|type>typy</a> i <a cbot|category>kategorie</a>."
@@ -613,7 +613,7 @@ msgid "Conditions"
 msgstr "Warunki"
 
 #. type: Plain text
-#: ../E/expr.txt:116
+#: ../E/expr.txt:117
 #, no-wrap
 msgid ""
 "<code>a == b  </code><code>a</code> equals <code>b</code>\n"
@@ -631,7 +631,7 @@ msgstr ""
 "<code>a >= b  </code><code>a</code> większe od lub równe <code>b</code>"
 
 #. type: Plain text
-#: ../E/expr.txt:124
+#: ../E/expr.txt:125
 #, no-wrap
 msgid ""
 "<code>12 == 12  </code>returns true\n"
@@ -649,13 +649,13 @@ msgstr ""
 "<code>12 >= 12  </code>daje w wyniku true "
 
 #. type: Plain text
-#: ../E/expr.txt:132
+#: ../E/expr.txt:133
 #, no-wrap
 msgid "Be careful not to confuse the equality comparison <code>==</code> with the assignment of a <a cbot|var>variable</a> <code>=</code>."
 msgstr "Nie należy mylić operatora porównania <code>==</code> z operatorem przypisania wartości <a cbot|var>zmiennej</a> <code>=</code>."
 
 #. type: Plain text
-#: ../E/expr.txt:134
+#: ../E/expr.txt:135
 #, no-wrap
 msgid ""
 "<code>a == b</code> is an expression that compares <code>a</code> with <code>b</code>.\n"
@@ -1255,29 +1255,13 @@ msgid "Expressions"
 msgstr "Wyrażenia"
 
 #. type: Plain text
-#: ../E/expr.txt:86
+#: ../E/expr.txt:87
 #, no-wrap
 msgid "is equivalent to"
 msgstr "jest równoważne"
 
 #. type: Plain text
-#: ../E/expr.txt:90
-#, no-wrap
-msgid ""
-"<code>+=</code>  addition\n"
-"<code>-=</code>  subtraction\n"
-"<code>*=</code>  multiplication\n"
-"<code>/=</code>  division\n"
-"<code>%=</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
-msgstr ""
-"<code>+=</code>  dodawanie\n"
-"<code>-=</code>  odejmowanie\n"
-"<code>*=</code>  mnożenie\n"
-"<code>/=</code>  dzielenie\n"
-"<code>%=</code>  reszta z dzielenia (tylko dla typu całkowitego <code><a cbot|int>int</a></code>)"
-
-#. type: Plain text
-#: ../E/expr.txt:178
+#: ../E/expr.txt:179
 #, no-wrap
 msgid "The operators <code>++</code> and <code>--</code> allow you to increment (++) or to decrement (--) a variable in very compact and efficient manner."
 msgstr "Operatory <code>++</code> i <code>--</code> umożliwiają wygodny i zwarty zapis zwiększania (++) lub zmniejszania (--) zmiennych."
@@ -2423,79 +2407,79 @@ msgid "Type <code>object</code>"
 msgstr "Typ <code>object</code>"
 
 #. type: Source code
-#: ../E/object.txt:21
+#: ../E/object.txt:22
 #, no-wrap
 msgid "<code>category</code>"
 msgstr "<code>category</code>"
 
 #. type: Source code
-#: ../E/object.txt:24
+#: ../E/object.txt:25
 #, no-wrap
 msgid "<code>position</code>"
 msgstr "<code>position</code>"
 
 #. type: Plain text
-#: ../E/object.txt:25
+#: ../E/object.txt:26
 #, no-wrap
 msgid "Position of the object on the planet, in meters. The coordinates <code>x</code> and <code>y</code> correspond to the location on a map, the <code>z</code> coordinate corresponds to the altitude above (respectively below) sea level. "
 msgstr "Położenie obiektu na planecie, w metrach. Współrzędne <code>x</code> i <code>y</code> odnoszą się do położenia na mapie, współrzędna <code>z</code> odpowiada wysokości nad (lub odpowiednio pod) poziomem morza. "
 
 #. type: Source code
-#: ../E/object.txt:27
+#: ../E/object.txt:28
 #, no-wrap
 msgid "<code>orientation</code>"
 msgstr "<code>orientation</code>"
 
 #. type: Plain text
-#: ../E/object.txt:28
+#: ../E/object.txt:29
 #, no-wrap
 msgid "Orientation of the object, in degrees. The orientation tells you what direction the object is facing. An orientation of <code>0</code> corresponds to an object facing eastwards, thus following the positive <code>x</code> axis. The orientation is measured counterclockwise. "
 msgstr "Orientacja obiektu, w stopniach. Określa kierunek, w którym obrócony jest obiekt. Wartość <code>0</code> odpowiada orientacji na wschód, zgodnie z dodatnią osią <code>x</code>. Orientacja liczona jest przeciwnie do ruchu wskazówek zegara. "
 
 #. type: Source code
-#: ../E/object.txt:30
+#: ../E/object.txt:31
 #, no-wrap
 msgid "<code>pitch</code>"
 msgstr "<code>pitch</code>"
 
 #. type: Plain text
-#: ../E/object.txt:31
+#: ../E/object.txt:32
 #, no-wrap
 msgid "Forward/backward angle of the robot. A pitch of <code>0</code> means that the bot is standing on flat ground. A positive inclination means that it is facing upwards, a negative inclination means that it is facing downwards. "
 msgstr "Pochylenie robota w przód/tył. Wartość <code>0</code> oznacza, że robot stoi na płaskim terenie. Wartość dodatnia oznacza, że robot \"patrzy\" w górę, wartość ujemna, że w dół. "
 
 #. type: Source code
-#: ../E/object.txt:33
+#: ../E/object.txt:34
 #, no-wrap
 msgid "<code>roll</code>"
 msgstr "<code>roll</code>"
 
 #. type: Plain text
-#: ../E/object.txt:34
+#: ../E/object.txt:35
 #, no-wrap
 msgid "Left/right angle of the bot, in degrees. A positive value means that the bot is leaning to the left side, a negative value means that it is leaning to the right side. "
 msgstr "Pochylenie robota w lewo/prawo. Wartość dodatnia oznacza, że robot jest przechylony na lewą stronę, wartość ujemna, że na prawą. "
 
 #. type: Source code
-#: ../E/object.txt:36
+#: ../E/object.txt:37
 #, no-wrap
 msgid "<code>energyLevel</code>"
 msgstr "<code>energyLevel</code>"
 
 #. type: Plain text
-#: ../E/object.txt:37
+#: ../E/object.txt:38
 #, no-wrap
 msgid "Energy level, between 0 and 1. A normal <a object|power>power cell</a> that is fully charged returns the value <code>1</code>. A <a object|atomic>nuclear power cell</a> never returns a value higher than 1, it just lasts longer. Attention: The energy level of a bot is always zero, because the energy is not contained in the bot, but in the power cell. To know the energy level of the power cell of a bot, you must write <code>energyCell.energyLevel</code>. "
 msgstr "Poziom energii, pomiędzy 0 i 1. Dla w pełni naładowanego <a object|power>zwykłego ogniwa elektrycznego</a> zwracana jest wartość <code>1</code>. <a object|atomic>Atomowe ogniwo elektryczne</a> nigdy nie zwraca wartości większej niż 1, jedynie działa dłużej. Uwaga: Poziom energii robota zawsze jest równy zero, gdyż energia nie jest zawarta w robocie ale w ogniwie elektrycznym. Aby poznać poziom energii ogniwa elektrycznego robota, należy napisać <code>energyCell.energyLevel</code>. "
 
 #. type: Source code
-#: ../E/object.txt:39
+#: ../E/object.txt:40
 #, no-wrap
 msgid "<code>shieldLevel</code>"
 msgstr "<code>shieldLevel</code>"
 
 #. type: Plain text
-#: ../E/object.txt:40
+#: ../E/object.txt:41
 #, no-wrap
 msgid ""
 "Shield level of a robot or building. A level <code>1</code> indicates that the shield is still perfect. Every time that the bot or building gets a bullet or collides with another object, the shield level decreases. When the level reaches <code>0</code>, the next bullet or collision will destroy the bot or building. \n"
@@ -2505,49 +2489,49 @@ msgstr ""
 "Roboty mogą zregenerować osłony w <a object|repair>warsztacie</a>. Powłoka budynku regenerowana jest gdy znajdzie się w zasięgu sfery ochronnej robota <a object|botshld>osłaniacza</a>."
 
 #. type: Source code
-#: ../E/object.txt:43
+#: ../E/object.txt:44
 #, no-wrap
 msgid "<code>temperature</code>"
 msgstr "<code>temperature</code>"
 
 #. type: Plain text
-#: ../E/object.txt:44
+#: ../E/object.txt:45
 #, no-wrap
 msgid "Temperature of the jet of <a object|botgj>winged bots</a>. <code>0</code> corresponds to a cold jet. When used, the temperature increases progressively. When it reaches the value <code>1</code>, the jet is overheated and stops working, until it cooled down a little. "
 msgstr "Temperatura silnika odrzutowego <a object|botgj>robotów latających</a>. <code>0</code> odpowiada zimnemu silnikowi. W miarę używania, wzrasta jego temperatura. Gdy osiągnie wartość <code>1</code>, silnik przegrzewa się i przestaje działać do czasu ostygnięcia. "
 
 #. type: Source code
-#: ../E/object.txt:46
+#: ../E/object.txt:47
 #, no-wrap
 msgid "<code>altitude</code>"
 msgstr "<code>altitude</code>"
 
 #. type: Plain text
-#: ../E/object.txt:47
+#: ../E/object.txt:48
 #, no-wrap
 msgid "The <code>z</code> coordinate of the position indicates the altitude above sea level, whereas the <code>altitude</code> indicates the height above ground. This value is meaningful only for <a object|botgj>winged bots</a> and for <a object|wasp>wasps</a>. For all other objects, this value is zero. "
 msgstr "Współrzędna <code>z</code> oznacza wysokość nad poziomem morza, podczas gdy <code>altitude</code> oznacza wysokość nad poziomem ziemi. Wartość ta ma znaczenie jedynie dla <a object|botgj>robotów latających</a> i <a object|wasp>os</a>. Dla pozostałych obiektów jest zerowa. "
 
 #. type: Source code
-#: ../E/object.txt:49
+#: ../E/object.txt:50
 #, no-wrap
 msgid "<code>lifeTime</code>"
 msgstr "<code>lifeTime</code>"
 
 #. type: Plain text
-#: ../E/object.txt:50
+#: ../E/object.txt:51
 #, no-wrap
 msgid "The age of the object in seconds since it's creation."
 msgstr "Wiek obiektów, w sekundach, od czasu ich powstania."
 
 #. type: Source code
-#: ../E/object.txt:52
+#: ../E/object.txt:53
 #, no-wrap
 msgid "<code>energyCell</code>"
 msgstr "<code>energyCell</code>"
 
 #. type: Plain text
-#: ../E/object.txt:53
+#: ../E/object.txt:54
 #, no-wrap
 msgid ""
 "This information is special, because it returns the information about another object, in this case the power pack. This means that energyCell contains all the characteristics of a normal object, for example <code>category</code> (PowerCell or NuclearCell), <code>position</code> (the position of the cell), etc.\n"
@@ -2559,31 +2543,31 @@ msgstr ""
 "Jeśli robot nie zawiera ogniwa elektrycznego, <code>energyCell</code> jest równe <code>null</code>."
 
 #. type: Source code
-#: ../E/object.txt:57
+#: ../E/object.txt:58
 #, no-wrap
 msgid "<code>load</code>"
 msgstr "<code>load</code>"
 
 #. type: Plain text
-#: ../E/object.txt:58
+#: ../E/object.txt:59
 #, no-wrap
 msgid "This information also returns the description of a whole object: the description of the object carried by a <a object|botgr>grabber</a>. If it carries nothing, <code>load</code> returns <code>null</code>."
 msgstr "Ta informacja również zwraca opis całego obiektu, a mianowicie opis obiektu trzymanego przez <a object|botgr>transporter</a>. Jeśli nie niesie on niczego, <code>load</code> jest równe <code>null</code>."
 
 #. type: \t; header, \b; header
-#: ../E/expr.txt:99 ../E/expr.txt:123 ../E/expr.txt:145 ../E/expr.txt:170 ../E/expr.txt:187 ../E/factory.txt:21 ../E/object.txt:66
+#: ../E/expr.txt:100 ../E/expr.txt:124 ../E/expr.txt:146 ../E/expr.txt:171 ../E/expr.txt:188 ../E/factory.txt:21 ../E/object.txt:70
 #, no-wrap
 msgid "Examples"
 msgstr "Przykłady"
 
 #. type: Plain text
-#: ../E/object.txt:67
+#: ../E/object.txt:71
 #, no-wrap
 msgid "The type <code>object</code> returns the special value <code><a cbot|null>null</a></code> when the object does not exist. For example:"
 msgstr "Typ <code>object</code> zwraca specjalną wartość <code><a cbot|null>null</a></code> gdy obiekt nie istnieje. Na przykład:"
 
 #. type: Source code
-#: ../E/object.txt:69
+#: ../E/object.txt:73
 #, no-wrap
 msgid ""
 "\tobject a;\n"
@@ -3215,7 +3199,7 @@ msgid "Returns the first object found that corresponds to the specified category
 msgstr "Zwraca pierwszy znaleziony obiekt odpowiadający podanej kategorii w podanej strefie. Jeśli nie znaleziono obiektu, zwracana jest wartość <code><a cbot|null>null</a></code>."
 
 #. type: \t; header
-#: ../E/expr.txt:131 ../E/radar.txt:68
+#: ../E/expr.txt:132 ../E/radar.txt:68
 #, no-wrap
 msgid "Remark"
 msgstr "Uwaga"
@@ -6497,71 +6481,37 @@ msgid "Use this type for variables that contain the characteristics of an object
 msgstr "Użyj tego typu dla zmiennych, które zawierają informacje o obiekcie, niezależnie od tego, czy jest to robot, budynek, materiał, przeciwnik itp. Obiekty mają następujące właściwości:"
 
 #. type: Plain text
-#: ../E/object.txt:4
-#, no-wrap
-msgid ""
-"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
-"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
-"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
-"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
-"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
-"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
-"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
-"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
-"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
-"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
-"<code>object object.energyCell   </code>Power cell on the bot\n"
-"<code>object object.load         </code>Object carried by the bot\n"
-"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
-"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object"
-msgstr ""
-"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Kategoria</a> obiektu\n"
-"<code><a cbot|point>point</a>  object.position     </code>Współrzędne obiektu (x,y,z)\n"
-"<code><a cbot|float>float</a>  object.orientation  </code>Kierunek obiektu (0..360)\n"
-"<code><a cbot|float>float</a>  object.pitch        </code>Pochylenie obiektu w przód lub w tył\n"
-"<code><a cbot|float>float</a>  object.roll         </code>Pochylenie obiektu w lewo lub w prawo\n"
-"<code><a cbot|float>float</a>  object.energyLevel  </code>Poziom energii (0..1)\n"
-"<code><a cbot|float>float</a>  object.shieldLevel  </code>Poziom osłony (0..1)\n"
-"<code><a cbot|float>float</a>  object.temperature  </code>Temperatura silnika (0..1)\n"
-"<code><a cbot|float>float</a>  object.altitude     </code>Wysokość nad poziomem gruntu\n"
-"<code><a cbot|float>float</a>  object.lifeTime     </code>Czas istnienia obiektu\n"
-"<code>object object.energyCell   </code>Ogniwo elektryczne robota\n"
-"<code>object object.load         </code>Obiekt trzymany przez robota\n"
-"<code><a cbot|int>int</a>    object.team         </code>Drużyna, do której należy obiekt (zobacz <a battles>programobitwy</a>)\n"
-"<code><a cbot|point>point</a>  object.velocity     </code>Prędkość obiektu"
-
-#. type: Plain text
-#: ../E/object.txt:19
+#: ../E/object.txt:20
 #, no-wrap
 msgid "Also, some objects have additional methods (instructions). See them in <a cbot>the main list</a> in the <c/>\"Instructions specific for some objects\" section."
 msgstr "Niektóre obiekty mają dodatkowe metody (instrukcje). Możesz je sprawdzić w sekcji <c/>\"Instrukcje charakterystyczne dla pewnych obiektów\" <a cbot>główne listy obiektów</a> "
 
 #. type: Plain text
-#: ../E/object.txt:22
+#: ../E/object.txt:23
 #, no-wrap
 msgid "The <n/><a cbot|category>category</a> of an object allows you to know what it is, f. ex. what kind of bot, building, enemy, etc."
 msgstr "<n/><a cbot|category>Kategoria</a> obiektu pozwala się się dowiedzieć, czym on jest, tzn. jaki to rodzaj robota, budynku, przeciwnika, itp."
 
 #. type: Source code
-#: ../E/object.txt:60
+#: ../E/object.txt:61
 #, no-wrap
 msgid "<code>team</code>"
 msgstr "<code>team</code>"
 
 #. type: Plain text
-#: ../E/object.txt:61
+#: ../E/object.txt:62
 #, no-wrap
 msgid "The bot's team. Used in <a battles>code battles</a>. If the object has no team assigned (e.g. in no team-based levels, the object being a resource), this is equal to <code>0</code>."
 msgstr "Drużyna robota. Ma zastosowanie w <a battles>programobitwach</a>. Jeśli obiekt nie należy do żadnej drużyny (np. gdy obiektem jest surowiec lub gdy obecny poziom nie jest programobitwą), wartość ta jest równa <code>0</code>."
 
 #. type: Source code
-#: ../E/object.txt:63
+#: ../E/object.txt:64
 #, no-wrap
 msgid "<code>velocity</code>"
 msgstr "<code>velocity</code>"
 
 #. type: Plain text
-#: ../E/object.txt:64
+#: ../E/object.txt:65
 #, no-wrap
 msgid "Current velocity of the object. Should be treated as a three-dimensional vector."
 msgstr "Aktualna prędkość obiektu. Powinna być traktowana jako wektor w przestrzeni trójwymiarowej."
@@ -7561,26 +7511,10 @@ msgid "Binary operators below are working with fundamental number types (<code><
 msgstr "Operatory binarne poniżej działają z podstawowymi typami liczb (<code><a cbot|int>int</a></code>, <code><a cbot|float>float</a></code>)."
 
 #. type: \t; header
-#: ../E/expr.txt:53 ../E/expr.txt:89 ../E/expr.txt:115 ../E/expr.txt:140 ../E/expr.txt:163
+#: ../E/expr.txt:53 ../E/expr.txt:90 ../E/expr.txt:116 ../E/expr.txt:141 ../E/expr.txt:164
 #, no-wrap
 msgid "List"
 msgstr "Lista"
-
-#. type: Plain text
-#: ../E/expr.txt:54
-#, no-wrap
-msgid ""
-"<code>+</code>  addition\n"
-"<code>-</code>  subtraction\n"
-"<code>*</code>  multiplication\n"
-"<code>/</code>  division\n"
-"<code>%</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
-msgstr ""
-"<code>+</code>  dodawanie\n"
-"<code>-</code>  odejmowanie\n"
-"<code>*</code>  mnożenie\n"
-"<code>/</code>  dzielenie\n"
-"<code>%</code>  reszta z dzielenia (tylko dla <code><a cbot|int>int</a></code>)"
 
 #. type: \t; header
 #: ../E/expr.txt:60
@@ -7607,49 +7541,49 @@ msgid "Real life examples"
 msgstr "Przykłady z życia wzięte"
 
 #. type: \t; header
-#: ../E/expr.txt:81
+#: ../E/expr.txt:82
 #, no-wrap
 msgid "Compound assignment operators"
 msgstr "Złożone operatory przypisania"
 
 #. type: Plain text
-#: ../E/expr.txt:82
+#: ../E/expr.txt:83
 #, no-wrap
 msgid "Besides the <code>=</code> operator for variable assignment there are several compound-assignment operators."
 msgstr "Oprócz operatora <code>=</code> do przypisywania zmiennych istnieją także różne złożone operatory przypisania."
 
 #. type: Plain text
-#: ../E/expr.txt:84
+#: ../E/expr.txt:85
 #, no-wrap
 msgid "The compound-assignment operators combine the <code>=</code> assignment operator with another binary operator such as <code>+</code> or <code>-</code>. Compound-assignment operators perform the operation specified by the additional operator and then assign the result to the left operand. For example, a compound-assignment expression such as"
 msgstr "Złożone operatory przypisania łączą operator przypisania <code>=</code> z innym operatorem binarnym, na przykład <code>+</code> lub <code>-</code>. Złożone operatory przypisania wykonują działanie określone przez dodatkowy operator, a następnie przypisują wynik do lewego operandu. Na przykład, taki złożony operator przypisania"
 
 #. type: Source code
-#: ../E/expr.txt:85
+#: ../E/expr.txt:86
 #, no-wrap
 msgid "<code>lvalue += expression</code>"
 msgstr "<code>l-wartość += wyrażenie</code>"
 
 #. type: Source code
-#: ../E/expr.txt:87
+#: ../E/expr.txt:88
 #, no-wrap
 msgid "<code>lvalue = lvalue + expression</code>"
 msgstr "<code>l-wartość = l-wartość + wyrażenie</code>"
 
 #. type: \b; header
-#: ../E/expr.txt:96
+#: ../E/expr.txt:97
 #, no-wrap
 msgid "String concatenation"
 msgstr "Łączenie łańcuchów znaków"
 
 #. type: Plain text
-#: ../E/expr.txt:97
+#: ../E/expr.txt:98
 #, no-wrap
 msgid "If at least one of the values used with the <code>+</code> operator is a <a cbot|string>string</a>, then the operation of concatenation is performed. The result of the operator is then a string, which is created by joining end-to-end the string and the other value. If the other value is not a string, then it is converted to string beforehand."
 msgstr "Jeśli przynajmniej jedna z wartości używanych z operatorem <code>+</code> jest <a cbot|string>łańcuchem znaków</a>, wtedy wykonywana jest operacja łączenia. Wynik operatora w takim razie jest łańcuchem znaków tworzonym przez dołączenie do łańcucha znaków innej wartości. Jeśli inna wartość nie jest łańcuchem zostaje najpierw przekonwertowana."
 
 #. type: Source code
-#: ../E/expr.txt:101
+#: ../E/expr.txt:102
 #, no-wrap
 msgid ""
 "\tstring s = \"a\" + \"bc\";  // returns \"abc\"\n"
@@ -7663,43 +7597,43 @@ msgstr ""
 "\tstring s = \"a\" + true;  // zwraca \"atrue\""
 
 #. type: Plain text
-#: ../E/expr.txt:106
+#: ../E/expr.txt:107
 #, no-wrap
 msgid "Tip: the properties of the concatenation <code>+</code> operator is useful with the <a cbot|message>message();</a> function, because it does not work with other types than string. An empty string can be used together with a value in order to create a string, which actually can be passed to the <a cbot|message>message();</a> function:"
 msgstr "Porada: właściwości operatora łączenia <code>+</code> są użyteczne podczas korzystania z funkcji <a cbot|message>message();</a>, ponieważ nie działa to ze zmiennymi innego typu niż string. Pusty łańcuch może być użyty razem z wartością, by stworzyć łańcuch, który może zostać przekazany do funkcji <a cbot|message>message();</a>:"
 
 #. type: \b; header
-#: ../E/expr.txt:177
+#: ../E/expr.txt:178
 #, no-wrap
 msgid "Prefix and postfix increment- and decrement operators"
 msgstr "Operatory zwiększania i zmniejszania przedrostka i przyrostka"
 
 #. type: Plain text
-#: ../E/expr.txt:180
+#: ../E/expr.txt:181
 #, no-wrap
 msgid "For example to increment the variable <code>a</code> you can write"
 msgstr "Na przykład: do zwiększenia wartości zmiennej <code>a</code> możesz napisać"
 
 #. type: Source code
-#: ../E/expr.txt:181
+#: ../E/expr.txt:182
 #, no-wrap
 msgid "<c/>a++;<n/>"
 msgstr "<c/>a++;<n/>"
 
 #. type: Plain text
-#: ../E/expr.txt:182
+#: ../E/expr.txt:183
 #, no-wrap
 msgid "instead of"
 msgstr "zamiast"
 
 #. type: Source code
-#: ../E/expr.txt:183
+#: ../E/expr.txt:184
 #, no-wrap
 msgid "<c/>a = a + 1;<n/>"
 msgstr "<c/>a = a + 1;<n/>"
 
 #. type: Plain text
-#: ../E/expr.txt:185
+#: ../E/expr.txt:186
 #, no-wrap
 msgid "The result of the operation <code>a++</code> is the value of the variable <code>a</code> *before* the increment. If you use the prefix operator <code>++a</code> the result of the operation is the value of the variable <code>a</code> *after* the increment. The same holds for the <code>--</code> decrement operator."
 msgstr "Wynik operacji <code>a++</code> jest równy wartości zmiennej <code>a</code> *przed* jej zwiększeniem. Jeśli użyjesz operatora przedrostkowego <code>++a</code> wynik operacji będzie wartością zmiennej <code>a</code> *po* jej zwiększeniu. To samo dotyczy się operatora zmniejszania <code>--</code>."
@@ -7723,41 +7657,7 @@ msgid "Note: it may be not obvious at first, but notice that <code>=</code> is a
 msgstr "Uwaga: to może nie być oczywiste na początku, ale zauważ, że <code>=</code> jest *operatorem*, nie instrukcją. To oznacza, że może zostać użyty przy tworzeniu innego wyrażenia! Wynik operatora <code>=</code> jest wartością, która została przypisana do l-wartości - inaczej mówiąc, operator ten zwraca wynik działania po jego prawej stronie. Przykład:"
 
 #. type: Source code
-#: ../E/expr.txt:66
-#, no-wrap
-msgid ""
-" int    i = 12 + 3;      // i == 15\n"
-" int    i = 2 - 5;       // i == -3\n"
-" \n"
-" float  f = 3.01 * 10;   // f == 30.1\n"
-" \n"
-" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
-" float  f = 5 / 3;       // f == 1.67\n"
-" float  f = 5 / 0;       // returns an error (division by zero)\n"
-" \n"
-" int    i = 13 % 5;      // i == 3\n"
-" int    i = -8 % 3;      // i == -2\n"
-" \n"
-" float  f = sin(90) * i; // f == -2.0\n"
-" "
-msgstr ""
-" int    i = 12 + 3;      // i == 15\n"
-" int    i = 2 - 5;       // i == -3\n"
-" \n"
-" float  f = 3.01 * 10;   // f == 30.1\n"
-" \n"
-" int    i = 5 / 3;       // i == 1 (automatyczna konwersja do int)\n"
-" float  f = 5 / 3;       // f == 1.67\n"
-" float  f = 5 / 0;       // zwraca błąd (dzielenie przez zero)\n"
-" \n"
-" int    i = 13 % 5;      // i == 3\n"
-" int    i = -8 % 3;      // i == -2\n"
-" \n"
-" float  f = sin(90) * i; // f == -2.0\n"
-" "
-
-#. type: Source code
-#: ../E/expr.txt:108
+#: ../E/expr.txt:109
 #, no-wrap
 msgid ""
 " float pi = 3.14;\n"
@@ -7769,7 +7669,7 @@ msgstr ""
 " message(\"\"+pi);"
 
 #. type: Source code
-#: ../E/expr.txt:189
+#: ../E/expr.txt:190
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -7781,7 +7681,7 @@ msgstr ""
 " // teraz b jest równe 2, natomiast a jest równe 3"
 
 #. type: Source code
-#: ../E/expr.txt:193
+#: ../E/expr.txt:194
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -7793,25 +7693,25 @@ msgstr ""
 " // teraz b jest równe 3, natomiast a również jest równe 3"
 
 #. type: \b; header
-#: ../E/expr.txt:137
+#: ../E/expr.txt:138
 #, no-wrap
 msgid "Logical operators"
 msgstr "Operatory logiczne"
 
 #. type: Plain text
-#: ../E/expr.txt:138
+#: ../E/expr.txt:139
 #, no-wrap
 msgid "Logical operators work with values of type <a cbot|bool>bool</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr "Operatory logiczne działają z wartościami typu <a cbot|bool>bool</a> i zawsze zwracają <a cbot|bool>bool</a>. Głównie używa się ich w <a cbot|cond>warunkach</a>."
 
 #. type: \b; header
-#: ../E/expr.txt:150
+#: ../E/expr.txt:151
 #, no-wrap
 msgid "Ternary operator"
 msgstr "Operatory trójskładnikowe"
 
 #. type: Plain text
-#: ../E/expr.txt:151
+#: ../E/expr.txt:152
 #, no-wrap
 msgid ""
 "The ternary operator is nothing more than a syntax sugar. It is also known as \"inline if\". It might be confusing at first, because its syntax is a little more complicated than other operators. It can be described as follows:\n"
@@ -7823,19 +7723,19 @@ msgstr ""
 "Nawiasy nie są wymagane."
 
 #. type: Plain text
-#: ../E/expr.txt:155
+#: ../E/expr.txt:156
 #, no-wrap
 msgid "Firstly, the condition is valued and then the first result is returned if the condition is true, otherwise the second result is returned."
 msgstr "Najpierw obliczany jest warunek i jeśli jest on prawdziwy, zwracany jest pierwszy wynik, w przeciwnym razie zwracany jest drugi wynik."
 
 #. type: \t; header
-#: ../E/expr.txt:157 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
+#: ../E/expr.txt:158 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
 #, no-wrap
 msgid "Example"
 msgstr "Przykład"
 
 #. type: Source code
-#: ../E/expr.txt:158
+#: ../E/expr.txt:159
 #, no-wrap
 msgid "<c/>float c = ((3.0 > 2.0) ? 10.0 : -10.0); // c == 10.0<n/>"
 msgstr "<c/>float c = ((3.0 > 2.0) ? 10.0 : -10.0); // c == 10.0<n/>"
@@ -7847,19 +7747,19 @@ msgid "A condition is a special <a cbot|expr>expression</a> that returns a <a cb
 msgstr "Warunek jest specjalnym <a cbot|expr>wyrażeniem</a>, które zwraca wartość typu <a cbot|bool>bool</a>, która może być albo <code><a cbot|true>prawdą</a></code> lub <code><a cbot|false>fałszem</a></code>. Dzięki warunkowi możesz wybrać np. czy instrukcja w pętli <code><a cbot|while>while</a></code> musi być wykonana ponownie, lub czy instrukcja w bloku <code><a cbot|if>if</a></code> ma zostać wykonana."
 
 #. type: \b; header
-#: ../E/expr.txt:112
+#: ../E/expr.txt:113
 #, no-wrap
 msgid "Comparison operators"
 msgstr "Operatory porównania"
 
 #. type: Plain text
-#: ../E/expr.txt:113
+#: ../E/expr.txt:114
 #, no-wrap
 msgid "Comparison operators work with values of type <a cbot|bool>float</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr "Operatory porównania działają z wartościami typu <a cbot|float>float</a> i zawsze zwracają <a cbot|bool>bool</a>. Używane są głównie w <a cbot|cond>warunkach</a>."
 
 #. type: Plain text
-#: ../E/expr.txt:141
+#: ../E/expr.txt:142
 #, no-wrap
 msgid ""
 "<code>!a      </code>not <code>a</code>\n"
@@ -7871,7 +7771,7 @@ msgstr ""
 "<code>a || b  </code><code>a</code> lub <code>b</code>"
 
 #. type: Plain text
-#: ../E/expr.txt:146
+#: ../E/expr.txt:147
 #, no-wrap
 msgid ""
 "<code>!false        </code>returns true\n"
@@ -7883,19 +7783,19 @@ msgstr ""
 "<code>true || false </code>zwraca true"
 
 #. type: \b; header
-#: ../E/expr.txt:160
+#: ../E/expr.txt:161
 #, no-wrap
 msgid "Bitwise operators"
 msgstr "Operatory bitowe"
 
 #. type: Plain text
-#: ../E/expr.txt:161
+#: ../E/expr.txt:162
 #, no-wrap
 msgid "Bitwise operators are similar to the logical operator, because they are operating on bits (which can be only 0 or 1, conditions can have a value only of false or true). So in theory, they should be working with basically any type of variable, because each value in the computer must be stored as a sequence of bits."
 msgstr "Operatory bitowe są podobne do operatorów logicznych, gdyż działają na bitach (które mogą być tylko zerami lub jedynkami, warunki mogą mieć tylko wartości false lub true). Więc w teorii powinny działać z praktycznie każdym typem zmiennej, ponieważ każda wartość w komputerze musi być przechowywana w postaci sekwencji bitów."
 
 #. type: Plain text
-#: ../E/expr.txt:164
+#: ../E/expr.txt:165
 #, no-wrap
 msgid ""
 "<code>a & b  </code><code>a</code> AND <code>b</code>\n"
@@ -7911,7 +7811,7 @@ msgstr ""
 "<code>a << b  </code>przesuń bity z <code>a</code> w lewą stronę <code>b</code> razy"
 
 #. type: Plain text
-#: ../E/expr.txt:171
+#: ../E/expr.txt:172
 #, no-wrap
 msgid ""
 "<code>2 & 1         </code>returns 0\n"
@@ -9535,4 +9435,80 @@ msgid ""
 " {\n"
 "     factory(WheeledGrabber, \"program/say-foo.cbot\");\n"
 " }"
+msgstr ""
+
+#. type: Plain text
+#: ../E/expr.txt:54
+#, no-wrap
+msgid ""
+"<code>+</code>  addition\n"
+"<code>-</code>  subtraction\n"
+"<code>*</code>  multiplication\n"
+"<code>/</code>  division\n"
+"<code>%</code>  remainder of the division (works for <code><a cbot|int>int</a></code> as well as <code><a cbot|float>float</a></code>)"
+msgstr ""
+
+#. type: Source code
+#: ../E/expr.txt:66
+#, no-wrap
+msgid ""
+" int    i = 12 + 3;      // i == 15\n"
+" int    i = 2 - 5;       // i == -3\n"
+" \n"
+" float  f = 3.01 * 10;   // f == 30.1\n"
+" \n"
+" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
+" float  f = 5 / 3;       // f == 1.67\n"
+" float  f = 5 / 0;       // returns an error (division by zero)\n"
+" \n"
+" int    i = 13 % 5;      // i == 3\n"
+" int    i = -8 % 3;      // i == -2\n"
+" float  f = -4.5 % 2.75; // f == -1.75\n"
+" \n"
+" float  f = sin(90) * i; // f == -2.0\n"
+" "
+msgstr ""
+
+#. type: Plain text
+#: ../E/expr.txt:91
+#, no-wrap
+msgid ""
+"<code>+=</code>  addition\n"
+"<code>-=</code>  subtraction\n"
+"<code>*=</code>  multiplication\n"
+"<code>/=</code>  division\n"
+"<code>%=</code>  remainder of the division"
+msgstr ""
+
+#. type: Plain text
+#: ../E/object.txt:4
+#, no-wrap
+msgid ""
+"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
+"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
+"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
+"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
+"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
+"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
+"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
+"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
+"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
+"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
+"<code>object object.energyCell   </code>Power cell on the bot\n"
+"<code>object object.load         </code>Object carried by the bot\n"
+"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
+"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object\n"
+"<code><a cbot|bool>bool</a>   object.dead         </code>Is the object dead?"
+msgstr ""
+
+#. type: Source code
+#: ../E/object.txt:67
+#, no-wrap
+msgid "<code>dead</code>"
+msgstr ""
+
+#. type: Plain text
+#: ../E/object.txt:68
+#, no-wrap
+msgid "True if the object was recently killed (while the death animation is playing). Note that accessing this property or any other property after the death animation finishes will cause an error that stops the program."
 msgstr ""

--- a/help/cbot/po/pl.po
+++ b/help/cbot/po/pl.po
@@ -53,13 +53,13 @@ msgid "Time in seconds."
 msgstr "Czas w sekundach."
 
 #. type: \t; header
-#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:198 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:83 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
+#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:197 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:79 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
 #, no-wrap
 msgid "See also"
 msgstr "Zobacz również"
 
 #. type: Plain text
-#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:199 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:84 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
+#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:198 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:80 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
 #, no-wrap
 msgid "<a cbot>Programming</a>, <a cbot|type>types</a> and <a cbot|category>categories</a>."
 msgstr "<a cbot>Programowanie</a>, <a cbot|type>typy</a> i <a cbot|category>kategorie</a>."
@@ -613,7 +613,7 @@ msgid "Conditions"
 msgstr "Warunki"
 
 #. type: Plain text
-#: ../E/expr.txt:117
+#: ../E/expr.txt:116
 #, no-wrap
 msgid ""
 "<code>a == b  </code><code>a</code> equals <code>b</code>\n"
@@ -631,7 +631,7 @@ msgstr ""
 "<code>a >= b  </code><code>a</code> większe od lub równe <code>b</code>"
 
 #. type: Plain text
-#: ../E/expr.txt:125
+#: ../E/expr.txt:124
 #, no-wrap
 msgid ""
 "<code>12 == 12  </code>returns true\n"
@@ -649,13 +649,13 @@ msgstr ""
 "<code>12 >= 12  </code>daje w wyniku true "
 
 #. type: Plain text
-#: ../E/expr.txt:133
+#: ../E/expr.txt:132
 #, no-wrap
 msgid "Be careful not to confuse the equality comparison <code>==</code> with the assignment of a <a cbot|var>variable</a> <code>=</code>."
 msgstr "Nie należy mylić operatora porównania <code>==</code> z operatorem przypisania wartości <a cbot|var>zmiennej</a> <code>=</code>."
 
 #. type: Plain text
-#: ../E/expr.txt:135
+#: ../E/expr.txt:134
 #, no-wrap
 msgid ""
 "<code>a == b</code> is an expression that compares <code>a</code> with <code>b</code>.\n"
@@ -1255,13 +1255,29 @@ msgid "Expressions"
 msgstr "Wyrażenia"
 
 #. type: Plain text
-#: ../E/expr.txt:87
+#: ../E/expr.txt:86
 #, no-wrap
 msgid "is equivalent to"
 msgstr "jest równoważne"
 
 #. type: Plain text
-#: ../E/expr.txt:179
+#: ../E/expr.txt:90
+#, no-wrap
+msgid ""
+"<code>+=</code>  addition\n"
+"<code>-=</code>  subtraction\n"
+"<code>*=</code>  multiplication\n"
+"<code>/=</code>  division\n"
+"<code>%=</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
+msgstr ""
+"<code>+=</code>  dodawanie\n"
+"<code>-=</code>  odejmowanie\n"
+"<code>*=</code>  mnożenie\n"
+"<code>/=</code>  dzielenie\n"
+"<code>%=</code>  reszta z dzielenia (tylko dla typu całkowitego <code><a cbot|int>int</a></code>)"
+
+#. type: Plain text
+#: ../E/expr.txt:178
 #, no-wrap
 msgid "The operators <code>++</code> and <code>--</code> allow you to increment (++) or to decrement (--) a variable in very compact and efficient manner."
 msgstr "Operatory <code>++</code> i <code>--</code> umożliwiają wygodny i zwarty zapis zwiększania (++) lub zmniejszania (--) zmiennych."
@@ -2407,79 +2423,79 @@ msgid "Type <code>object</code>"
 msgstr "Typ <code>object</code>"
 
 #. type: Source code
-#: ../E/object.txt:22
+#: ../E/object.txt:21
 #, no-wrap
 msgid "<code>category</code>"
 msgstr "<code>category</code>"
 
 #. type: Source code
-#: ../E/object.txt:25
+#: ../E/object.txt:24
 #, no-wrap
 msgid "<code>position</code>"
 msgstr "<code>position</code>"
 
 #. type: Plain text
-#: ../E/object.txt:26
+#: ../E/object.txt:25
 #, no-wrap
 msgid "Position of the object on the planet, in meters. The coordinates <code>x</code> and <code>y</code> correspond to the location on a map, the <code>z</code> coordinate corresponds to the altitude above (respectively below) sea level. "
 msgstr "Położenie obiektu na planecie, w metrach. Współrzędne <code>x</code> i <code>y</code> odnoszą się do położenia na mapie, współrzędna <code>z</code> odpowiada wysokości nad (lub odpowiednio pod) poziomem morza. "
 
 #. type: Source code
-#: ../E/object.txt:28
+#: ../E/object.txt:27
 #, no-wrap
 msgid "<code>orientation</code>"
 msgstr "<code>orientation</code>"
 
 #. type: Plain text
-#: ../E/object.txt:29
+#: ../E/object.txt:28
 #, no-wrap
 msgid "Orientation of the object, in degrees. The orientation tells you what direction the object is facing. An orientation of <code>0</code> corresponds to an object facing eastwards, thus following the positive <code>x</code> axis. The orientation is measured counterclockwise. "
 msgstr "Orientacja obiektu, w stopniach. Określa kierunek, w którym obrócony jest obiekt. Wartość <code>0</code> odpowiada orientacji na wschód, zgodnie z dodatnią osią <code>x</code>. Orientacja liczona jest przeciwnie do ruchu wskazówek zegara. "
 
 #. type: Source code
-#: ../E/object.txt:31
+#: ../E/object.txt:30
 #, no-wrap
 msgid "<code>pitch</code>"
 msgstr "<code>pitch</code>"
 
 #. type: Plain text
-#: ../E/object.txt:32
+#: ../E/object.txt:31
 #, no-wrap
 msgid "Forward/backward angle of the robot. A pitch of <code>0</code> means that the bot is standing on flat ground. A positive inclination means that it is facing upwards, a negative inclination means that it is facing downwards. "
 msgstr "Pochylenie robota w przód/tył. Wartość <code>0</code> oznacza, że robot stoi na płaskim terenie. Wartość dodatnia oznacza, że robot \"patrzy\" w górę, wartość ujemna, że w dół. "
 
 #. type: Source code
-#: ../E/object.txt:34
+#: ../E/object.txt:33
 #, no-wrap
 msgid "<code>roll</code>"
 msgstr "<code>roll</code>"
 
 #. type: Plain text
-#: ../E/object.txt:35
+#: ../E/object.txt:34
 #, no-wrap
 msgid "Left/right angle of the bot, in degrees. A positive value means that the bot is leaning to the left side, a negative value means that it is leaning to the right side. "
 msgstr "Pochylenie robota w lewo/prawo. Wartość dodatnia oznacza, że robot jest przechylony na lewą stronę, wartość ujemna, że na prawą. "
 
 #. type: Source code
-#: ../E/object.txt:37
+#: ../E/object.txt:36
 #, no-wrap
 msgid "<code>energyLevel</code>"
 msgstr "<code>energyLevel</code>"
 
 #. type: Plain text
-#: ../E/object.txt:38
+#: ../E/object.txt:37
 #, no-wrap
 msgid "Energy level, between 0 and 1. A normal <a object|power>power cell</a> that is fully charged returns the value <code>1</code>. A <a object|atomic>nuclear power cell</a> never returns a value higher than 1, it just lasts longer. Attention: The energy level of a bot is always zero, because the energy is not contained in the bot, but in the power cell. To know the energy level of the power cell of a bot, you must write <code>energyCell.energyLevel</code>. "
 msgstr "Poziom energii, pomiędzy 0 i 1. Dla w pełni naładowanego <a object|power>zwykłego ogniwa elektrycznego</a> zwracana jest wartość <code>1</code>. <a object|atomic>Atomowe ogniwo elektryczne</a> nigdy nie zwraca wartości większej niż 1, jedynie działa dłużej. Uwaga: Poziom energii robota zawsze jest równy zero, gdyż energia nie jest zawarta w robocie ale w ogniwie elektrycznym. Aby poznać poziom energii ogniwa elektrycznego robota, należy napisać <code>energyCell.energyLevel</code>. "
 
 #. type: Source code
-#: ../E/object.txt:40
+#: ../E/object.txt:39
 #, no-wrap
 msgid "<code>shieldLevel</code>"
 msgstr "<code>shieldLevel</code>"
 
 #. type: Plain text
-#: ../E/object.txt:41
+#: ../E/object.txt:40
 #, no-wrap
 msgid ""
 "Shield level of a robot or building. A level <code>1</code> indicates that the shield is still perfect. Every time that the bot or building gets a bullet or collides with another object, the shield level decreases. When the level reaches <code>0</code>, the next bullet or collision will destroy the bot or building. \n"
@@ -2489,49 +2505,49 @@ msgstr ""
 "Roboty mogą zregenerować osłony w <a object|repair>warsztacie</a>. Powłoka budynku regenerowana jest gdy znajdzie się w zasięgu sfery ochronnej robota <a object|botshld>osłaniacza</a>."
 
 #. type: Source code
-#: ../E/object.txt:44
+#: ../E/object.txt:43
 #, no-wrap
 msgid "<code>temperature</code>"
 msgstr "<code>temperature</code>"
 
 #. type: Plain text
-#: ../E/object.txt:45
+#: ../E/object.txt:44
 #, no-wrap
 msgid "Temperature of the jet of <a object|botgj>winged bots</a>. <code>0</code> corresponds to a cold jet. When used, the temperature increases progressively. When it reaches the value <code>1</code>, the jet is overheated and stops working, until it cooled down a little. "
 msgstr "Temperatura silnika odrzutowego <a object|botgj>robotów latających</a>. <code>0</code> odpowiada zimnemu silnikowi. W miarę używania, wzrasta jego temperatura. Gdy osiągnie wartość <code>1</code>, silnik przegrzewa się i przestaje działać do czasu ostygnięcia. "
 
 #. type: Source code
-#: ../E/object.txt:47
+#: ../E/object.txt:46
 #, no-wrap
 msgid "<code>altitude</code>"
 msgstr "<code>altitude</code>"
 
 #. type: Plain text
-#: ../E/object.txt:48
+#: ../E/object.txt:47
 #, no-wrap
 msgid "The <code>z</code> coordinate of the position indicates the altitude above sea level, whereas the <code>altitude</code> indicates the height above ground. This value is meaningful only for <a object|botgj>winged bots</a> and for <a object|wasp>wasps</a>. For all other objects, this value is zero. "
 msgstr "Współrzędna <code>z</code> oznacza wysokość nad poziomem morza, podczas gdy <code>altitude</code> oznacza wysokość nad poziomem ziemi. Wartość ta ma znaczenie jedynie dla <a object|botgj>robotów latających</a> i <a object|wasp>os</a>. Dla pozostałych obiektów jest zerowa. "
 
 #. type: Source code
-#: ../E/object.txt:50
+#: ../E/object.txt:49
 #, no-wrap
 msgid "<code>lifeTime</code>"
 msgstr "<code>lifeTime</code>"
 
 #. type: Plain text
-#: ../E/object.txt:51
+#: ../E/object.txt:50
 #, no-wrap
 msgid "The age of the object in seconds since it's creation."
 msgstr "Wiek obiektów, w sekundach, od czasu ich powstania."
 
 #. type: Source code
-#: ../E/object.txt:53
+#: ../E/object.txt:52
 #, no-wrap
 msgid "<code>energyCell</code>"
 msgstr "<code>energyCell</code>"
 
 #. type: Plain text
-#: ../E/object.txt:54
+#: ../E/object.txt:53
 #, no-wrap
 msgid ""
 "This information is special, because it returns the information about another object, in this case the power pack. This means that energyCell contains all the characteristics of a normal object, for example <code>category</code> (PowerCell or NuclearCell), <code>position</code> (the position of the cell), etc.\n"
@@ -2543,31 +2559,31 @@ msgstr ""
 "Jeśli robot nie zawiera ogniwa elektrycznego, <code>energyCell</code> jest równe <code>null</code>."
 
 #. type: Source code
-#: ../E/object.txt:58
+#: ../E/object.txt:57
 #, no-wrap
 msgid "<code>load</code>"
 msgstr "<code>load</code>"
 
 #. type: Plain text
-#: ../E/object.txt:59
+#: ../E/object.txt:58
 #, no-wrap
 msgid "This information also returns the description of a whole object: the description of the object carried by a <a object|botgr>grabber</a>. If it carries nothing, <code>load</code> returns <code>null</code>."
 msgstr "Ta informacja również zwraca opis całego obiektu, a mianowicie opis obiektu trzymanego przez <a object|botgr>transporter</a>. Jeśli nie niesie on niczego, <code>load</code> jest równe <code>null</code>."
 
 #. type: \t; header, \b; header
-#: ../E/expr.txt:100 ../E/expr.txt:124 ../E/expr.txt:146 ../E/expr.txt:171 ../E/expr.txt:188 ../E/factory.txt:21 ../E/object.txt:70
+#: ../E/expr.txt:99 ../E/expr.txt:123 ../E/expr.txt:145 ../E/expr.txt:170 ../E/expr.txt:187 ../E/factory.txt:21 ../E/object.txt:66
 #, no-wrap
 msgid "Examples"
 msgstr "Przykłady"
 
 #. type: Plain text
-#: ../E/object.txt:71
+#: ../E/object.txt:67
 #, no-wrap
 msgid "The type <code>object</code> returns the special value <code><a cbot|null>null</a></code> when the object does not exist. For example:"
 msgstr "Typ <code>object</code> zwraca specjalną wartość <code><a cbot|null>null</a></code> gdy obiekt nie istnieje. Na przykład:"
 
 #. type: Source code
-#: ../E/object.txt:73
+#: ../E/object.txt:69
 #, no-wrap
 msgid ""
 "\tobject a;\n"
@@ -3199,7 +3215,7 @@ msgid "Returns the first object found that corresponds to the specified category
 msgstr "Zwraca pierwszy znaleziony obiekt odpowiadający podanej kategorii w podanej strefie. Jeśli nie znaleziono obiektu, zwracana jest wartość <code><a cbot|null>null</a></code>."
 
 #. type: \t; header
-#: ../E/expr.txt:132 ../E/radar.txt:68
+#: ../E/expr.txt:131 ../E/radar.txt:68
 #, no-wrap
 msgid "Remark"
 msgstr "Uwaga"
@@ -6481,37 +6497,71 @@ msgid "Use this type for variables that contain the characteristics of an object
 msgstr "Użyj tego typu dla zmiennych, które zawierają informacje o obiekcie, niezależnie od tego, czy jest to robot, budynek, materiał, przeciwnik itp. Obiekty mają następujące właściwości:"
 
 #. type: Plain text
-#: ../E/object.txt:20
+#: ../E/object.txt:4
+#, no-wrap
+msgid ""
+"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
+"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
+"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
+"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
+"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
+"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
+"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
+"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
+"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
+"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
+"<code>object object.energyCell   </code>Power cell on the bot\n"
+"<code>object object.load         </code>Object carried by the bot\n"
+"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
+"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object"
+msgstr ""
+"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Kategoria</a> obiektu\n"
+"<code><a cbot|point>point</a>  object.position     </code>Współrzędne obiektu (x,y,z)\n"
+"<code><a cbot|float>float</a>  object.orientation  </code>Kierunek obiektu (0..360)\n"
+"<code><a cbot|float>float</a>  object.pitch        </code>Pochylenie obiektu w przód lub w tył\n"
+"<code><a cbot|float>float</a>  object.roll         </code>Pochylenie obiektu w lewo lub w prawo\n"
+"<code><a cbot|float>float</a>  object.energyLevel  </code>Poziom energii (0..1)\n"
+"<code><a cbot|float>float</a>  object.shieldLevel  </code>Poziom osłony (0..1)\n"
+"<code><a cbot|float>float</a>  object.temperature  </code>Temperatura silnika (0..1)\n"
+"<code><a cbot|float>float</a>  object.altitude     </code>Wysokość nad poziomem gruntu\n"
+"<code><a cbot|float>float</a>  object.lifeTime     </code>Czas istnienia obiektu\n"
+"<code>object object.energyCell   </code>Ogniwo elektryczne robota\n"
+"<code>object object.load         </code>Obiekt trzymany przez robota\n"
+"<code><a cbot|int>int</a>    object.team         </code>Drużyna, do której należy obiekt (zobacz <a battles>programobitwy</a>)\n"
+"<code><a cbot|point>point</a>  object.velocity     </code>Prędkość obiektu"
+
+#. type: Plain text
+#: ../E/object.txt:19
 #, no-wrap
 msgid "Also, some objects have additional methods (instructions). See them in <a cbot>the main list</a> in the <c/>\"Instructions specific for some objects\" section."
 msgstr "Niektóre obiekty mają dodatkowe metody (instrukcje). Możesz je sprawdzić w sekcji <c/>\"Instrukcje charakterystyczne dla pewnych obiektów\" <a cbot>główne listy obiektów</a> "
 
 #. type: Plain text
-#: ../E/object.txt:23
+#: ../E/object.txt:22
 #, no-wrap
 msgid "The <n/><a cbot|category>category</a> of an object allows you to know what it is, f. ex. what kind of bot, building, enemy, etc."
 msgstr "<n/><a cbot|category>Kategoria</a> obiektu pozwala się się dowiedzieć, czym on jest, tzn. jaki to rodzaj robota, budynku, przeciwnika, itp."
 
 #. type: Source code
-#: ../E/object.txt:61
+#: ../E/object.txt:60
 #, no-wrap
 msgid "<code>team</code>"
 msgstr "<code>team</code>"
 
 #. type: Plain text
-#: ../E/object.txt:62
+#: ../E/object.txt:61
 #, no-wrap
 msgid "The bot's team. Used in <a battles>code battles</a>. If the object has no team assigned (e.g. in no team-based levels, the object being a resource), this is equal to <code>0</code>."
 msgstr "Drużyna robota. Ma zastosowanie w <a battles>programobitwach</a>. Jeśli obiekt nie należy do żadnej drużyny (np. gdy obiektem jest surowiec lub gdy obecny poziom nie jest programobitwą), wartość ta jest równa <code>0</code>."
 
 #. type: Source code
-#: ../E/object.txt:64
+#: ../E/object.txt:63
 #, no-wrap
 msgid "<code>velocity</code>"
 msgstr "<code>velocity</code>"
 
 #. type: Plain text
-#: ../E/object.txt:65
+#: ../E/object.txt:64
 #, no-wrap
 msgid "Current velocity of the object. Should be treated as a three-dimensional vector."
 msgstr "Aktualna prędkość obiektu. Powinna być traktowana jako wektor w przestrzeni trójwymiarowej."
@@ -7511,10 +7561,26 @@ msgid "Binary operators below are working with fundamental number types (<code><
 msgstr "Operatory binarne poniżej działają z podstawowymi typami liczb (<code><a cbot|int>int</a></code>, <code><a cbot|float>float</a></code>)."
 
 #. type: \t; header
-#: ../E/expr.txt:53 ../E/expr.txt:90 ../E/expr.txt:116 ../E/expr.txt:141 ../E/expr.txt:164
+#: ../E/expr.txt:53 ../E/expr.txt:89 ../E/expr.txt:115 ../E/expr.txt:140 ../E/expr.txt:163
 #, no-wrap
 msgid "List"
 msgstr "Lista"
+
+#. type: Plain text
+#: ../E/expr.txt:54
+#, no-wrap
+msgid ""
+"<code>+</code>  addition\n"
+"<code>-</code>  subtraction\n"
+"<code>*</code>  multiplication\n"
+"<code>/</code>  division\n"
+"<code>%</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
+msgstr ""
+"<code>+</code>  dodawanie\n"
+"<code>-</code>  odejmowanie\n"
+"<code>*</code>  mnożenie\n"
+"<code>/</code>  dzielenie\n"
+"<code>%</code>  reszta z dzielenia (tylko dla <code><a cbot|int>int</a></code>)"
 
 #. type: \t; header
 #: ../E/expr.txt:60
@@ -7541,49 +7607,49 @@ msgid "Real life examples"
 msgstr "Przykłady z życia wzięte"
 
 #. type: \t; header
-#: ../E/expr.txt:82
+#: ../E/expr.txt:81
 #, no-wrap
 msgid "Compound assignment operators"
 msgstr "Złożone operatory przypisania"
 
 #. type: Plain text
-#: ../E/expr.txt:83
+#: ../E/expr.txt:82
 #, no-wrap
 msgid "Besides the <code>=</code> operator for variable assignment there are several compound-assignment operators."
 msgstr "Oprócz operatora <code>=</code> do przypisywania zmiennych istnieją także różne złożone operatory przypisania."
 
 #. type: Plain text
-#: ../E/expr.txt:85
+#: ../E/expr.txt:84
 #, no-wrap
 msgid "The compound-assignment operators combine the <code>=</code> assignment operator with another binary operator such as <code>+</code> or <code>-</code>. Compound-assignment operators perform the operation specified by the additional operator and then assign the result to the left operand. For example, a compound-assignment expression such as"
 msgstr "Złożone operatory przypisania łączą operator przypisania <code>=</code> z innym operatorem binarnym, na przykład <code>+</code> lub <code>-</code>. Złożone operatory przypisania wykonują działanie określone przez dodatkowy operator, a następnie przypisują wynik do lewego operandu. Na przykład, taki złożony operator przypisania"
 
 #. type: Source code
-#: ../E/expr.txt:86
+#: ../E/expr.txt:85
 #, no-wrap
 msgid "<code>lvalue += expression</code>"
 msgstr "<code>l-wartość += wyrażenie</code>"
 
 #. type: Source code
-#: ../E/expr.txt:88
+#: ../E/expr.txt:87
 #, no-wrap
 msgid "<code>lvalue = lvalue + expression</code>"
 msgstr "<code>l-wartość = l-wartość + wyrażenie</code>"
 
 #. type: \b; header
-#: ../E/expr.txt:97
+#: ../E/expr.txt:96
 #, no-wrap
 msgid "String concatenation"
 msgstr "Łączenie łańcuchów znaków"
 
 #. type: Plain text
-#: ../E/expr.txt:98
+#: ../E/expr.txt:97
 #, no-wrap
 msgid "If at least one of the values used with the <code>+</code> operator is a <a cbot|string>string</a>, then the operation of concatenation is performed. The result of the operator is then a string, which is created by joining end-to-end the string and the other value. If the other value is not a string, then it is converted to string beforehand."
 msgstr "Jeśli przynajmniej jedna z wartości używanych z operatorem <code>+</code> jest <a cbot|string>łańcuchem znaków</a>, wtedy wykonywana jest operacja łączenia. Wynik operatora w takim razie jest łańcuchem znaków tworzonym przez dołączenie do łańcucha znaków innej wartości. Jeśli inna wartość nie jest łańcuchem zostaje najpierw przekonwertowana."
 
 #. type: Source code
-#: ../E/expr.txt:102
+#: ../E/expr.txt:101
 #, no-wrap
 msgid ""
 "\tstring s = \"a\" + \"bc\";  // returns \"abc\"\n"
@@ -7597,43 +7663,43 @@ msgstr ""
 "\tstring s = \"a\" + true;  // zwraca \"atrue\""
 
 #. type: Plain text
-#: ../E/expr.txt:107
+#: ../E/expr.txt:106
 #, no-wrap
 msgid "Tip: the properties of the concatenation <code>+</code> operator is useful with the <a cbot|message>message();</a> function, because it does not work with other types than string. An empty string can be used together with a value in order to create a string, which actually can be passed to the <a cbot|message>message();</a> function:"
 msgstr "Porada: właściwości operatora łączenia <code>+</code> są użyteczne podczas korzystania z funkcji <a cbot|message>message();</a>, ponieważ nie działa to ze zmiennymi innego typu niż string. Pusty łańcuch może być użyty razem z wartością, by stworzyć łańcuch, który może zostać przekazany do funkcji <a cbot|message>message();</a>:"
 
 #. type: \b; header
-#: ../E/expr.txt:178
+#: ../E/expr.txt:177
 #, no-wrap
 msgid "Prefix and postfix increment- and decrement operators"
 msgstr "Operatory zwiększania i zmniejszania przedrostka i przyrostka"
 
 #. type: Plain text
-#: ../E/expr.txt:181
+#: ../E/expr.txt:180
 #, no-wrap
 msgid "For example to increment the variable <code>a</code> you can write"
 msgstr "Na przykład: do zwiększenia wartości zmiennej <code>a</code> możesz napisać"
 
 #. type: Source code
-#: ../E/expr.txt:182
+#: ../E/expr.txt:181
 #, no-wrap
 msgid "<c/>a++;<n/>"
 msgstr "<c/>a++;<n/>"
 
 #. type: Plain text
-#: ../E/expr.txt:183
+#: ../E/expr.txt:182
 #, no-wrap
 msgid "instead of"
 msgstr "zamiast"
 
 #. type: Source code
-#: ../E/expr.txt:184
+#: ../E/expr.txt:183
 #, no-wrap
 msgid "<c/>a = a + 1;<n/>"
 msgstr "<c/>a = a + 1;<n/>"
 
 #. type: Plain text
-#: ../E/expr.txt:186
+#: ../E/expr.txt:185
 #, no-wrap
 msgid "The result of the operation <code>a++</code> is the value of the variable <code>a</code> *before* the increment. If you use the prefix operator <code>++a</code> the result of the operation is the value of the variable <code>a</code> *after* the increment. The same holds for the <code>--</code> decrement operator."
 msgstr "Wynik operacji <code>a++</code> jest równy wartości zmiennej <code>a</code> *przed* jej zwiększeniem. Jeśli użyjesz operatora przedrostkowego <code>++a</code> wynik operacji będzie wartością zmiennej <code>a</code> *po* jej zwiększeniu. To samo dotyczy się operatora zmniejszania <code>--</code>."
@@ -7657,7 +7723,41 @@ msgid "Note: it may be not obvious at first, but notice that <code>=</code> is a
 msgstr "Uwaga: to może nie być oczywiste na początku, ale zauważ, że <code>=</code> jest *operatorem*, nie instrukcją. To oznacza, że może zostać użyty przy tworzeniu innego wyrażenia! Wynik operatora <code>=</code> jest wartością, która została przypisana do l-wartości - inaczej mówiąc, operator ten zwraca wynik działania po jego prawej stronie. Przykład:"
 
 #. type: Source code
-#: ../E/expr.txt:109
+#: ../E/expr.txt:66
+#, no-wrap
+msgid ""
+" int    i = 12 + 3;      // i == 15\n"
+" int    i = 2 - 5;       // i == -3\n"
+" \n"
+" float  f = 3.01 * 10;   // f == 30.1\n"
+" \n"
+" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
+" float  f = 5 / 3;       // f == 1.67\n"
+" float  f = 5 / 0;       // returns an error (division by zero)\n"
+" \n"
+" int    i = 13 % 5;      // i == 3\n"
+" int    i = -8 % 3;      // i == -2\n"
+" \n"
+" float  f = sin(90) * i; // f == -2.0\n"
+" "
+msgstr ""
+" int    i = 12 + 3;      // i == 15\n"
+" int    i = 2 - 5;       // i == -3\n"
+" \n"
+" float  f = 3.01 * 10;   // f == 30.1\n"
+" \n"
+" int    i = 5 / 3;       // i == 1 (automatyczna konwersja do int)\n"
+" float  f = 5 / 3;       // f == 1.67\n"
+" float  f = 5 / 0;       // zwraca błąd (dzielenie przez zero)\n"
+" \n"
+" int    i = 13 % 5;      // i == 3\n"
+" int    i = -8 % 3;      // i == -2\n"
+" \n"
+" float  f = sin(90) * i; // f == -2.0\n"
+" "
+
+#. type: Source code
+#: ../E/expr.txt:108
 #, no-wrap
 msgid ""
 " float pi = 3.14;\n"
@@ -7669,7 +7769,7 @@ msgstr ""
 " message(\"\"+pi);"
 
 #. type: Source code
-#: ../E/expr.txt:190
+#: ../E/expr.txt:189
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -7681,7 +7781,7 @@ msgstr ""
 " // teraz b jest równe 2, natomiast a jest równe 3"
 
 #. type: Source code
-#: ../E/expr.txt:194
+#: ../E/expr.txt:193
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -7693,25 +7793,25 @@ msgstr ""
 " // teraz b jest równe 3, natomiast a również jest równe 3"
 
 #. type: \b; header
-#: ../E/expr.txt:138
+#: ../E/expr.txt:137
 #, no-wrap
 msgid "Logical operators"
 msgstr "Operatory logiczne"
 
 #. type: Plain text
-#: ../E/expr.txt:139
+#: ../E/expr.txt:138
 #, no-wrap
 msgid "Logical operators work with values of type <a cbot|bool>bool</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr "Operatory logiczne działają z wartościami typu <a cbot|bool>bool</a> i zawsze zwracają <a cbot|bool>bool</a>. Głównie używa się ich w <a cbot|cond>warunkach</a>."
 
 #. type: \b; header
-#: ../E/expr.txt:151
+#: ../E/expr.txt:150
 #, no-wrap
 msgid "Ternary operator"
 msgstr "Operatory trójskładnikowe"
 
 #. type: Plain text
-#: ../E/expr.txt:152
+#: ../E/expr.txt:151
 #, no-wrap
 msgid ""
 "The ternary operator is nothing more than a syntax sugar. It is also known as \"inline if\". It might be confusing at first, because its syntax is a little more complicated than other operators. It can be described as follows:\n"
@@ -7723,19 +7823,19 @@ msgstr ""
 "Nawiasy nie są wymagane."
 
 #. type: Plain text
-#: ../E/expr.txt:156
+#: ../E/expr.txt:155
 #, no-wrap
 msgid "Firstly, the condition is valued and then the first result is returned if the condition is true, otherwise the second result is returned."
 msgstr "Najpierw obliczany jest warunek i jeśli jest on prawdziwy, zwracany jest pierwszy wynik, w przeciwnym razie zwracany jest drugi wynik."
 
 #. type: \t; header
-#: ../E/expr.txt:158 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
+#: ../E/expr.txt:157 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
 #, no-wrap
 msgid "Example"
 msgstr "Przykład"
 
 #. type: Source code
-#: ../E/expr.txt:159
+#: ../E/expr.txt:158
 #, no-wrap
 msgid "<c/>float c = ((3.0 > 2.0) ? 10.0 : -10.0); // c == 10.0<n/>"
 msgstr "<c/>float c = ((3.0 > 2.0) ? 10.0 : -10.0); // c == 10.0<n/>"
@@ -7747,19 +7847,19 @@ msgid "A condition is a special <a cbot|expr>expression</a> that returns a <a cb
 msgstr "Warunek jest specjalnym <a cbot|expr>wyrażeniem</a>, które zwraca wartość typu <a cbot|bool>bool</a>, która może być albo <code><a cbot|true>prawdą</a></code> lub <code><a cbot|false>fałszem</a></code>. Dzięki warunkowi możesz wybrać np. czy instrukcja w pętli <code><a cbot|while>while</a></code> musi być wykonana ponownie, lub czy instrukcja w bloku <code><a cbot|if>if</a></code> ma zostać wykonana."
 
 #. type: \b; header
-#: ../E/expr.txt:113
+#: ../E/expr.txt:112
 #, no-wrap
 msgid "Comparison operators"
 msgstr "Operatory porównania"
 
 #. type: Plain text
-#: ../E/expr.txt:114
+#: ../E/expr.txt:113
 #, no-wrap
 msgid "Comparison operators work with values of type <a cbot|bool>float</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr "Operatory porównania działają z wartościami typu <a cbot|float>float</a> i zawsze zwracają <a cbot|bool>bool</a>. Używane są głównie w <a cbot|cond>warunkach</a>."
 
 #. type: Plain text
-#: ../E/expr.txt:142
+#: ../E/expr.txt:141
 #, no-wrap
 msgid ""
 "<code>!a      </code>not <code>a</code>\n"
@@ -7771,7 +7871,7 @@ msgstr ""
 "<code>a || b  </code><code>a</code> lub <code>b</code>"
 
 #. type: Plain text
-#: ../E/expr.txt:147
+#: ../E/expr.txt:146
 #, no-wrap
 msgid ""
 "<code>!false        </code>returns true\n"
@@ -7783,19 +7883,19 @@ msgstr ""
 "<code>true || false </code>zwraca true"
 
 #. type: \b; header
-#: ../E/expr.txt:161
+#: ../E/expr.txt:160
 #, no-wrap
 msgid "Bitwise operators"
 msgstr "Operatory bitowe"
 
 #. type: Plain text
-#: ../E/expr.txt:162
+#: ../E/expr.txt:161
 #, no-wrap
 msgid "Bitwise operators are similar to the logical operator, because they are operating on bits (which can be only 0 or 1, conditions can have a value only of false or true). So in theory, they should be working with basically any type of variable, because each value in the computer must be stored as a sequence of bits."
 msgstr "Operatory bitowe są podobne do operatorów logicznych, gdyż działają na bitach (które mogą być tylko zerami lub jedynkami, warunki mogą mieć tylko wartości false lub true). Więc w teorii powinny działać z praktycznie każdym typem zmiennej, ponieważ każda wartość w komputerze musi być przechowywana w postaci sekwencji bitów."
 
 #. type: Plain text
-#: ../E/expr.txt:165
+#: ../E/expr.txt:164
 #, no-wrap
 msgid ""
 "<code>a & b  </code><code>a</code> AND <code>b</code>\n"
@@ -7811,7 +7911,7 @@ msgstr ""
 "<code>a << b  </code>przesuń bity z <code>a</code> w lewą stronę <code>b</code> razy"
 
 #. type: Plain text
-#: ../E/expr.txt:172
+#: ../E/expr.txt:171
 #, no-wrap
 msgid ""
 "<code>2 & 1         </code>returns 0\n"
@@ -9436,119 +9536,3 @@ msgid ""
 "     factory(WheeledGrabber, \"program/say-foo.cbot\");\n"
 " }"
 msgstr ""
-
-#. type: Plain text
-#: ../E/expr.txt:54
-#, no-wrap
-msgid ""
-"<code>+</code>  addition\n"
-"<code>-</code>  subtraction\n"
-"<code>*</code>  multiplication\n"
-"<code>/</code>  division\n"
-"<code>%</code>  remainder of the division (works for <code><a cbot|int>int</a></code> as well as <code><a cbot|float>float</a></code>)"
-msgstr ""
-"<code>+</code>  dodawanie\n"
-"<code>-</code>  odejmowanie\n"
-"<code>*</code>  mnożenie\n"
-"<code>/</code>  dzielenie\n"
-"<code>%</code>  reszta z dzielenia (działa dla <code><a cbot|int>int</a></code> oraz <code><a cbot|float>float</a></code>)"
-
-#. type: Source code
-#: ../E/expr.txt:66
-#, no-wrap
-msgid ""
-" int    i = 12 + 3;      // i == 15\n"
-" int    i = 2 - 5;       // i == -3\n"
-" \n"
-" float  f = 3.01 * 10;   // f == 30.1\n"
-" \n"
-" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
-" float  f = 5 / 3;       // f == 1.67\n"
-" float  f = 5 / 0;       // returns an error (division by zero)\n"
-" \n"
-" int    i = 13 % 5;      // i == 3\n"
-" int    i = -8 % 3;      // i == -2\n"
-" float  f = -4.5 % 2.75; // f == -1.75\n"
-" \n"
-" float  f = sin(90) * i; // f == -2.0\n"
-" "
-msgstr ""
-" int    i = 12 + 3;      // i == 15\n"
-" int    i = 2 - 5;       // i == -3\n"
-" \n"
-" float  f = 3.01 * 10;   // f == 30.1\n"
-" \n"
-" int    i = 5 / 3;       // i == 1 (automatyczna konwersja do int)\n"
-" float  f = 5 / 3;       // f == 1.67\n"
-" float  f = 5 / 0;       // zwraca błąd (dzielenie przez zero)\n"
-" \n"
-" int    i = 13 % 5;      // i == 3\n"
-" int    i = -8 % 3;      // i == -2\n"
-" float  f = -4.5 % 2.75; // f == -1.75\n"
-" \n"
-" float  f = sin(90) * i; // f == -2.0\n"
-" "
-
-#. type: Plain text
-#: ../E/expr.txt:91
-#, no-wrap
-msgid ""
-"<code>+=</code>  addition\n"
-"<code>-=</code>  subtraction\n"
-"<code>*=</code>  multiplication\n"
-"<code>/=</code>  division\n"
-"<code>%=</code>  remainder of the division"
-msgstr ""
-"<code>+=</code>  dodawanie\n"
-"<code>-=</code>  odejmowanie\n"
-"<code>*=</code>  mnożenie\n"
-"<code>/=</code>  dzielenie\n"
-"<code>%=</code>  reszta z dzielenia"
-
-#. type: Plain text
-#: ../E/object.txt:4
-#, no-wrap
-msgid ""
-"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
-"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
-"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
-"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
-"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
-"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
-"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
-"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
-"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
-"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
-"<code>object object.energyCell   </code>Power cell on the bot\n"
-"<code>object object.load         </code>Object carried by the bot\n"
-"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
-"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object\n"
-"<code><a cbot|bool>bool</a>   object.dead         </code>Is the object dead?"
-msgstr ""
-"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Kategoria</a> obiektu\n"
-"<code><a cbot|point>point</a>  object.position     </code>Współrzędne obiektu (x,y,z)\n"
-"<code><a cbot|float>float</a>  object.orientation  </code>Kierunek obiektu (0..360)\n"
-"<code><a cbot|float>float</a>  object.pitch        </code>Pochylenie obiektu w przód lub w tył\n"
-"<code><a cbot|float>float</a>  object.roll         </code>Pochylenie obiektu w lewo lub w prawo\n"
-"<code><a cbot|float>float</a>  object.energyLevel  </code>Poziom energii (0..1)\n"
-"<code><a cbot|float>float</a>  object.shieldLevel  </code>Poziom osłony (0..1)\n"
-"<code><a cbot|float>float</a>  object.temperature  </code>Temperatura silnika (0..1)\n"
-"<code><a cbot|float>float</a>  object.altitude     </code>Wysokość nad poziomem gruntu\n"
-"<code><a cbot|float>float</a>  object.lifeTime     </code>Czas istnienia obiektu\n"
-"<code>object object.energyCell   </code>Ogniwo elektryczne robota\n"
-"<code>object object.load         </code>Obiekt trzymany przez robota\n"
-"<code><a cbot|int>int</a>    object.team         </code>Drużyna, do której należy obiekt (zobacz <a battles>programobitwy</a>)\n"
-"<code><a cbot|point>point</a>  object.velocity     </code>Prędkość obiektu\n"
-"<code><a cbot|bool>bool</a>   object.dead         </code>Czy obiekt jest martwy?"
-
-#. type: Source code
-#: ../E/object.txt:67
-#, no-wrap
-msgid "<code>dead</code>"
-msgstr ""
-
-#. type: Plain text
-#: ../E/object.txt:68
-#, no-wrap
-msgid "True if the object was recently killed (while the death animation is playing). Note that accessing this property or any other property after the death animation finishes will cause an error that stops the program."
-msgstr "True, jeśli obiekt został niedawno zabity (podczas odtwarzania animacji śmierci). Należy pamiętać, że uzyskanie dostępu do tej właściwości lub jakiejkolwiek innej właściwości po zakończeniu animacji śmierci spowoduje błąd, który zatrzyma program."

--- a/help/cbot/po/pl.po
+++ b/help/cbot/po/pl.po
@@ -9360,13 +9360,13 @@ msgstr ""
 #: ../E/factory.txt:11
 #, no-wrap
 msgid "Program that will be run on the bot after factory finishes the construction. This can be either a <a cbot|public>public</a> <a cbot|function>function</a>, a filename or raw code."
-msgstr "Program ten zostanie uruchomiony po zakończeniu pracy przez fabrykę. To może być zarówno <a cbot|public>publiczna</a> <a cbot|function>funkcja</a>, nazwa pliku lub czysty kod."
+msgstr ""
 
 #. type: Plain text
 #: ../E/factory.txt:23
 #, no-wrap
 msgid "Raw code:"
-msgstr "Czysty kod:"
+msgstr ""
 
 #. type: Source code
 #: ../E/factory.txt:25
@@ -9382,7 +9382,7 @@ msgstr ""
 #: ../E/factory.txt:31
 #, no-wrap
 msgid "Public function:"
-msgstr "Publiczna funkcja:"
+msgstr ""
 
 #. type: Source code
 #: ../E/factory.txt:33
@@ -9403,13 +9403,13 @@ msgstr ""
 #: ../E/factory.txt:44
 #, no-wrap
 msgid "File name:"
-msgstr "Nazwa pliku:"
+msgstr ""
 
 #. type: Plain text
 #: ../E/factory.txt:46
 #, no-wrap
 msgid "Save this as say-foo.cbot. Note: make sure to check the \"Public\" checkbox when saving - this will cause say-foo.cbot to be inside the program/ folder."
-msgstr "Zapisz to jako say-foo.cbot. Uwaga: upewnij się, że zaznaczyłeś pole wyboru \"Publiczny\" podczas zapisywania - spowoduje to, że say-foo.cbot znajdzie się w folderze program/."
+msgstr ""
 
 #. type: Source code
 #: ../E/factory.txt:48
@@ -9425,7 +9425,7 @@ msgstr ""
 #: ../E/factory.txt:54
 #, no-wrap
 msgid "Run factory like this:"
-msgstr "Użyj funkcji factory w następujący sposób:"
+msgstr ""
 
 #. type: Source code
 #: ../E/factory.txt:56

--- a/help/cbot/po/pt.po
+++ b/help/cbot/po/pt.po
@@ -9070,13 +9070,13 @@ msgstr ""
 #: ../E/factory.txt:5
 #, no-wrap
 msgid "Starts a construction of a bot of a given <a cbot|category>category</a> and runs a specified program on it after the construction is finished."
-msgstr "Inicia uma construção de um bot de uma determinada <a cbot|category>categoria</a> e executa um programa especificado nele depois que a construção é concluída."
+msgstr ""
 
 #. type: Plain text
 #: ../E/factory.txt:14
 #, no-wrap
 msgid "<a object|factory>BotFactory</a>, nearest by default."
-msgstr "<a object|factory>BotFactory</a>, mais próximo por padrão."
+msgstr ""
 
 #. type: Plain text
 #: ../E/factory.txt:62
@@ -9312,13 +9312,13 @@ msgstr ""
 #: ../E/factory.txt:11
 #, no-wrap
 msgid "Program that will be run on the bot after factory finishes the construction. This can be either a <a cbot|public>public</a> <a cbot|function>function</a>, a filename or raw code."
-msgstr "Programa que será executado no bot após a fábrica terminar a construção. Isso pode ser uma <a cbot|function>função</a> <a cbot|public>pública</a>, um nome de arquivo ou um trecho de código."
+msgstr ""
 
 #. type: Plain text
 #: ../E/factory.txt:23
 #, no-wrap
 msgid "Raw code:"
-msgstr "Trecho de código:"
+msgstr ""
 
 #. type: Source code
 #: ../E/factory.txt:25
@@ -9334,7 +9334,7 @@ msgstr ""
 #: ../E/factory.txt:31
 #, no-wrap
 msgid "Public function:"
-msgstr "Função pública:"
+msgstr ""
 
 #. type: Source code
 #: ../E/factory.txt:33
@@ -9355,13 +9355,13 @@ msgstr ""
 #: ../E/factory.txt:44
 #, no-wrap
 msgid "File name:"
-msgstr "Nome de arquivo:"
+msgstr ""
 
 #. type: Plain text
 #: ../E/factory.txt:46
 #, no-wrap
 msgid "Save this as say-foo.cbot. Note: make sure to check the \"Public\" checkbox when saving - this will cause say-foo.cbot to be inside the program/ folder."
-msgstr "Salve isso como say-foo.cbot. Nota: certifique-se de marcar a caixa de seleção \"Público\" ao salvar - isso fará com que say-foo.cbot esteja dentro do program/ pasta."
+msgstr ""
 
 #. type: Source code
 #: ../E/factory.txt:48
@@ -9377,7 +9377,7 @@ msgstr ""
 #: ../E/factory.txt:54
 #, no-wrap
 msgid "Run factory like this:"
-msgstr "Use a função de factory assim:"
+msgstr ""
 
 #. type: Source code
 #: ../E/factory.txt:56

--- a/help/cbot/po/pt.po
+++ b/help/cbot/po/pt.po
@@ -53,13 +53,13 @@ msgid "Time in seconds."
 msgstr "Tempo em segundos."
 
 #. type: \t; header
-#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:198 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:83 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
+#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:197 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:79 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
 #, no-wrap
 msgid "See also"
 msgstr "Veja também"
 
 #. type: Plain text
-#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:199 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:84 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
+#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:198 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:80 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
 #, no-wrap
 msgid "<a cbot>Programming</a>, <a cbot|type>types</a> and <a cbot|category>categories</a>."
 msgstr "<a cbot>Programação</a>, <a cbot|type>tipos</a> e <a cbot|category>categorias</a>."
@@ -615,7 +615,7 @@ msgid "Conditions"
 msgstr "Condições"
 
 #. type: Plain text
-#: ../E/expr.txt:117
+#: ../E/expr.txt:116
 #, no-wrap
 msgid ""
 "<code>a == b  </code><code>a</code> equals <code>b</code>\n"
@@ -633,7 +633,7 @@ msgstr ""
 "<code>a >= b  </code><code>a</code> é maior ou igual a <code>b</code>"
 
 #. type: Plain text
-#: ../E/expr.txt:125
+#: ../E/expr.txt:124
 #, no-wrap
 msgid ""
 "<code>12 == 12  </code>returns true\n"
@@ -651,13 +651,13 @@ msgstr ""
 "<code>12 >= 12  </code>retorna true "
 
 #. type: Plain text
-#: ../E/expr.txt:133
+#: ../E/expr.txt:132
 #, no-wrap
 msgid "Be careful not to confuse the equality comparison <code>==</code> with the assignment of a <a cbot|var>variable</a> <code>=</code>."
 msgstr "Tenha cuidado para não confundir o operador de comparação <code>==</code> com o operadoratribuição de valor a <a cbot|var>variáveis</a> <code>=</code>."
 
 #. type: Plain text
-#: ../E/expr.txt:135
+#: ../E/expr.txt:134
 #, no-wrap
 msgid ""
 "<code>a == b</code> is an expression that compares <code>a</code> with <code>b</code>.\n"
@@ -1263,13 +1263,29 @@ msgid "Expressions"
 msgstr "Expressões"
 
 #. type: Plain text
-#: ../E/expr.txt:87
+#: ../E/expr.txt:86
 #, no-wrap
 msgid "is equivalent to"
 msgstr "é equivalente a"
 
 #. type: Plain text
-#: ../E/expr.txt:179
+#: ../E/expr.txt:90
+#, no-wrap
+msgid ""
+"<code>+=</code>  addition\n"
+"<code>-=</code>  subtraction\n"
+"<code>*=</code>  multiplication\n"
+"<code>/=</code>  division\n"
+"<code>%=</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
+msgstr ""
+"<code>+=</code>  adição\n"
+"<code>-=</code>  subtração\n"
+"<code>*=</code>  multiplicação\n"
+"<code>/=</code>  divisão\n"
+"<code>%=</code>  resto da divisão (somente para o tipo <code><a cbot|int>int</a></code>)"
+
+#. type: Plain text
+#: ../E/expr.txt:178
 #, no-wrap
 msgid "The operators <code>++</code> and <code>--</code> allow you to increment (++) or to decrement (--) a variable in very compact and efficient manner."
 msgstr "Os operadores <code>++</code> e <code>--</code> permitem a você incrementar (++)ou decrementar (--) uma variável de uma maneira bem compacta e eficiente."
@@ -2415,79 +2431,79 @@ msgid "Type <code>object</code>"
 msgstr "Tipo <code>object</code>"
 
 #. type: Source code
-#: ../E/object.txt:22
+#: ../E/object.txt:21
 #, no-wrap
 msgid "<code>category</code>"
 msgstr "<code>category</code>"
 
 #. type: Source code
-#: ../E/object.txt:25
+#: ../E/object.txt:24
 #, no-wrap
 msgid "<code>position</code>"
 msgstr "<code>position</code>"
 
 #. type: Plain text
-#: ../E/object.txt:26
+#: ../E/object.txt:25
 #, no-wrap
 msgid "Position of the object on the planet, in meters. The coordinates <code>x</code> and <code>y</code> correspond to the location on a map, the <code>z</code> coordinate corresponds to the altitude above (respectively below) sea level. "
 msgstr "Posição do objeto no planeta, em metros. As coordenadas <code>x</code> e <code>y</code> correspondem ao local no mapa, a coordenada <code>z</code> corresponde a altitude acima (respectivamente abaixo) no nível do mar."
 
 #. type: Source code
-#: ../E/object.txt:28
+#: ../E/object.txt:27
 #, no-wrap
 msgid "<code>orientation</code>"
 msgstr "<code>orientation</code>"
 
 #. type: Plain text
-#: ../E/object.txt:29
+#: ../E/object.txt:28
 #, no-wrap
 msgid "Orientation of the object, in degrees. The orientation tells you what direction the object is facing. An orientation of <code>0</code> corresponds to an object facing eastwards, thus following the positive <code>x</code> axis. The orientation is measured counterclockwise. "
 msgstr "Orientação do objeto, em graus. A orientação diz a você qual a direção que o objeto está apontando. Uma orientação de <code>0</code>corresponde a um objeto virado para o leste, sendo assim, seguindo o eixo positivo <code>x</code>. A orientação é medida em sentido anti-horário. "
 
 #. type: Source code
-#: ../E/object.txt:31
+#: ../E/object.txt:30
 #, no-wrap
 msgid "<code>pitch</code>"
 msgstr "<code>pitch</code>"
 
 #. type: Plain text
-#: ../E/object.txt:32
+#: ../E/object.txt:31
 #, no-wrap
 msgid "Forward/backward angle of the robot. A pitch of <code>0</code> means that the bot is standing on flat ground. A positive inclination means that it is facing upwards, a negative inclination means that it is facing downwards. "
 msgstr "Ângulo para frente / para trás do robô. Um pitch de <code>0</code> significa que o robô está em solo plano. Uma inclinação positiva significa que ele está olhando para cima, uma inclinação negativa significa que ele está olhando para baixo."
 
 #. type: Source code
-#: ../E/object.txt:34
+#: ../E/object.txt:33
 #, no-wrap
 msgid "<code>roll</code>"
 msgstr "<code>roll</code>"
 
 #. type: Plain text
-#: ../E/object.txt:35
+#: ../E/object.txt:34
 #, no-wrap
 msgid "Left/right angle of the bot, in degrees. A positive value means that the bot is leaning to the left side, a negative value means that it is leaning to the right side. "
 msgstr "Ângulo direito / esquerdo do robô, em graus. Um valor positivo significa que o robô está inclinado para o lado esquerdo, um valor negativo significa que o robô está inclinado para o lado direito."
 
 #. type: Source code
-#: ../E/object.txt:37
+#: ../E/object.txt:36
 #, no-wrap
 msgid "<code>energyLevel</code>"
 msgstr "<code>energyLevel</code>"
 
 #. type: Plain text
-#: ../E/object.txt:38
+#: ../E/object.txt:37
 #, no-wrap
 msgid "Energy level, between 0 and 1. A normal <a object|power>power cell</a> that is fully charged returns the value <code>1</code>. A <a object|atomic>nuclear power cell</a> never returns a value higher than 1, it just lasts longer. Attention: The energy level of a bot is always zero, because the energy is not contained in the bot, but in the power cell. To know the energy level of the power cell of a bot, you must write <code>energyCell.energyLevel</code>. "
 msgstr "Nível de energia, entre 0 e 1. Uma <a object|power>célula de energia</a> normal que está totalmente carregada retorna o valor <code>1</code>. Uma <a object|atomic>célula de energia nuclear</a>  nunca retorna um valor maior que 1, ela apenas dura mais. Atenção: o nível de energia de um robô é sempre zero, porque a energia não está no robô, mas sim na célula de energia. Para saber o nível de energia que resta na célula de um robô, você deve escrever <code>energyCell.energyLevel</code>. "
 
 #. type: Source code
-#: ../E/object.txt:40
+#: ../E/object.txt:39
 #, no-wrap
 msgid "<code>shieldLevel</code>"
 msgstr "<code>shieldLevel</code>"
 
 #. type: Plain text
-#: ../E/object.txt:41
+#: ../E/object.txt:40
 #, no-wrap
 msgid ""
 "Shield level of a robot or building. A level <code>1</code> indicates that the shield is still perfect. Every time that the bot or building gets a bullet or collides with another object, the shield level decreases. When the level reaches <code>0</code>, the next bullet or collision will destroy the bot or building. \n"
@@ -2497,49 +2513,49 @@ msgstr ""
 "Robôs podem reenergizar seus escudos em um <a object|repair>centro de reparo</a>. O escudo de um edifício é reparado se ele estiver dentro da esfera de proteção de um  <a object|botshld>protetor</a>."
 
 #. type: Source code
-#: ../E/object.txt:44
+#: ../E/object.txt:43
 #, no-wrap
 msgid "<code>temperature</code>"
 msgstr "<code>temperature</code>"
 
 #. type: Plain text
-#: ../E/object.txt:45
+#: ../E/object.txt:44
 #, no-wrap
 msgid "Temperature of the jet of <a object|botgj>winged bots</a>. <code>0</code> corresponds to a cold jet. When used, the temperature increases progressively. When it reaches the value <code>1</code>, the jet is overheated and stops working, until it cooled down a little. "
 msgstr "Temperatura do jato de <a object|botgj>robôs alados</a>. <code>0</code> corresponde a um jato frio. Quando usado, a temperatura aumenta progressivamente. Quando ela atinge o valor <code>1</code>, o jato está superaquecido e para de funcionar, até que ele esfrie um pouco."
 
 #. type: Source code
-#: ../E/object.txt:47
+#: ../E/object.txt:46
 #, no-wrap
 msgid "<code>altitude</code>"
 msgstr "<code>altitude</code>"
 
 #. type: Plain text
-#: ../E/object.txt:48
+#: ../E/object.txt:47
 #, no-wrap
 msgid "The <code>z</code> coordinate of the position indicates the altitude above sea level, whereas the <code>altitude</code> indicates the height above ground. This value is meaningful only for <a object|botgj>winged bots</a> and for <a object|wasp>wasps</a>. For all other objects, this value is zero. "
 msgstr "A coordenada <code>z</code> da posição indica a altitude acima do nível do mar, enquando a  <code>altitude</code> indica a altura acima do chão. Este valor só é útil para <a object|botgj>robôs alados</a> e para <a object|wasp>vespas</a>.  Para todos os outros objetos, este valor é zero."
 
 #. type: Source code
-#: ../E/object.txt:50
+#: ../E/object.txt:49
 #, no-wrap
 msgid "<code>lifeTime</code>"
 msgstr "<code>lifeTime</code>"
 
 #. type: Plain text
-#: ../E/object.txt:51
+#: ../E/object.txt:50
 #, no-wrap
 msgid "The age of the object in seconds since it's creation."
 msgstr "A idade de um objeto em segundos desde a sua criação."
 
 #. type: Source code
-#: ../E/object.txt:53
+#: ../E/object.txt:52
 #, no-wrap
 msgid "<code>energyCell</code>"
 msgstr "<code>energyCell</code>"
 
 #. type: Plain text
-#: ../E/object.txt:54
+#: ../E/object.txt:53
 #, no-wrap
 msgid ""
 "This information is special, because it returns the information about another object, in this case the power pack. This means that energyCell contains all the characteristics of a normal object, for example <code>category</code> (PowerCell or NuclearCell), <code>position</code> (the position of the cell), etc.\n"
@@ -2551,31 +2567,31 @@ msgstr ""
 "Se o robô não tiver uma célula de energia, <code>energyCell</code> retorna <code>null</code>."
 
 #. type: Source code
-#: ../E/object.txt:58
+#: ../E/object.txt:57
 #, no-wrap
 msgid "<code>load</code>"
 msgstr "<code>load</code>"
 
 #. type: Plain text
-#: ../E/object.txt:59
+#: ../E/object.txt:58
 #, no-wrap
 msgid "This information also returns the description of a whole object: the description of the object carried by a <a object|botgr>grabber</a>. If it carries nothing, <code>load</code> returns <code>null</code>."
 msgstr "Esta informação também retorna a descrição de um objeto completo: a descrição do objeto carregado por um <a object|botgr>agarrador</a>. Se ele não carrega nada, <code>load</code> retorna <code>null</code>."
 
 #. type: \t; header, \b; header
-#: ../E/expr.txt:100 ../E/expr.txt:124 ../E/expr.txt:146 ../E/expr.txt:171 ../E/expr.txt:188 ../E/factory.txt:21 ../E/object.txt:70
+#: ../E/expr.txt:99 ../E/expr.txt:123 ../E/expr.txt:145 ../E/expr.txt:170 ../E/expr.txt:187 ../E/factory.txt:21 ../E/object.txt:66
 #, no-wrap
 msgid "Examples"
 msgstr "Exemplos"
 
 #. type: Plain text
-#: ../E/object.txt:71
+#: ../E/object.txt:67
 #, no-wrap
 msgid "The type <code>object</code> returns the special value <code><a cbot|null>null</a></code> when the object does not exist. For example:"
 msgstr "O tipo <code>object</code> retorna o valor especial <code><a cbot|null>null</a></code>quando o objeto não existe. Por exemplo:"
 
 #. type: Source code
-#: ../E/object.txt:73
+#: ../E/object.txt:69
 #, no-wrap
 msgid ""
 "\tobject a;\n"
@@ -3207,7 +3223,7 @@ msgid "Returns the first object found that corresponds to the specified category
 msgstr "Retorna o primeiro objeto encontrado que corresponda a categoria na zona especificada. Se nenhum objeto for encontrado, retorna o valor <code><a cbot|null>null</a></code>."
 
 #. type: \t; header
-#: ../E/expr.txt:132 ../E/radar.txt:68
+#: ../E/expr.txt:131 ../E/radar.txt:68
 #, no-wrap
 msgid "Remark"
 msgstr "Observação"
@@ -6489,37 +6505,71 @@ msgid "Use this type for variables that contain the characteristics of an object
 msgstr "Use este tipo para variáveis que contém as características de um objeto, seja ele um robô, um edifício, alguma matéria prima, um inimigo, etc. Aqui estão todas as propriedades de um objeto:"
 
 #. type: Plain text
-#: ../E/object.txt:20
+#: ../E/object.txt:4
+#, no-wrap
+msgid ""
+"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
+"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
+"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
+"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
+"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
+"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
+"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
+"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
+"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
+"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
+"<code>object object.energyCell   </code>Power cell on the bot\n"
+"<code>object object.load         </code>Object carried by the bot\n"
+"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
+"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object"
+msgstr ""
+"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Categoria</a> do objeto\n"
+"<code><a cbot|point>point</a>  object.position     </code>Posição do objeto (x,y,z)\n"
+"<code><a cbot|float>float</a>  object.orientation  </code>Orientação do objeto (0..360)\n"
+"<code><a cbot|float>float</a>  object.pitch        </code>Ângulo de avanço / retrocesso do objeto\n"
+"<code><a cbot|float>float</a>  object.roll         </code>Ângulo direito / esquerdo do objeto \n"
+"<code><a cbot|float>float</a>  object.energyLevel  </code>Nível de energia (0..1)\n"
+"<code><a cbot|float>float</a>  object.shieldLevel  </code>Nível do escudo (0..1)\n"
+"<code><a cbot|float>float</a>  object.temperature  </code>Temperatura do jato (0..1)\n"
+"<code><a cbot|float>float</a>  object.altitude     </code>Altitude acima do chão\n"
+"<code><a cbot|float>float</a>  object.lifeTime     </code>Tempo de vida do objeto\n"
+"<code>object object.energyCell   </code>Célula de energia do robô\n"
+"<code>object object.load         </code>Objeto carregado pelo robô\n"
+"<code><a cbot|int>int</a>    object.team         </code>A equipe do objeto (veja <a battles>códigos de batalhas</a>)\n"
+"<code><a cbot|point>point</a>  object.velocity     </code>Velocidade do objeto"
+
+#. type: Plain text
+#: ../E/object.txt:19
 #, no-wrap
 msgid "Also, some objects have additional methods (instructions). See them in <a cbot>the main list</a> in the <c/>\"Instructions specific for some objects\" section."
 msgstr "Além diso, alguns objetos possuem métodos adicionais (instruções). Veja eles na <a cbot>lista principal</a>, na seção <c/>\"Instruções especificas para alguns objetos\"."
 
 #. type: Plain text
-#: ../E/object.txt:23
+#: ../E/object.txt:22
 #, no-wrap
 msgid "The <n/><a cbot|category>category</a> of an object allows you to know what it is, f. ex. what kind of bot, building, enemy, etc."
 msgstr "A <n/><a cbot|category>categoria</a> de um objeto permite a você conhecer o que ele é, por exemplo, qual tipo de robô, edifício, inimigo, etc."
 
 #. type: Source code
-#: ../E/object.txt:61
+#: ../E/object.txt:60
 #, no-wrap
 msgid "<code>team</code>"
 msgstr "<code>team</code>"
 
 #. type: Plain text
-#: ../E/object.txt:62
+#: ../E/object.txt:61
 #, no-wrap
 msgid "The bot's team. Used in <a battles>code battles</a>. If the object has no team assigned (e.g. in no team-based levels, the object being a resource), this is equal to <code>0</code>."
 msgstr "A equipe do robô. Usada em <a battles>batalhas de código</a>. Se o objeto não tem equipe atribuída (isto é, em nenhum nível de equipe, o objeto sendo um recurso), isto é igual a <code>0</code>."
 
 #. type: Source code
-#: ../E/object.txt:64
+#: ../E/object.txt:63
 #, no-wrap
 msgid "<code>velocity</code>"
 msgstr "<code>velocity</code>"
 
 #. type: Plain text
-#: ../E/object.txt:65
+#: ../E/object.txt:64
 #, no-wrap
 msgid "Current velocity of the object. Should be treated as a three-dimensional vector."
 msgstr "Velocidade atual do objeto. Deve ser tratada como um vetor de três dimensões."
@@ -7519,10 +7569,26 @@ msgid "Binary operators below are working with fundamental number types (<code><
 msgstr "As operações binárias abaixo funcionam com os tipos numéricos fundamentais (<code><a cbot|int>int</a></code>, <code><a cbot|float>float</a></code>)."
 
 #. type: \t; header
-#: ../E/expr.txt:53 ../E/expr.txt:90 ../E/expr.txt:116 ../E/expr.txt:141 ../E/expr.txt:164
+#: ../E/expr.txt:53 ../E/expr.txt:89 ../E/expr.txt:115 ../E/expr.txt:140 ../E/expr.txt:163
 #, no-wrap
 msgid "List"
 msgstr "Lista"
+
+#. type: Plain text
+#: ../E/expr.txt:54
+#, no-wrap
+msgid ""
+"<code>+</code>  addition\n"
+"<code>-</code>  subtraction\n"
+"<code>*</code>  multiplication\n"
+"<code>/</code>  division\n"
+"<code>%</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
+msgstr ""
+"<code>+</code>  adição\n"
+"<code>-</code>  subtração\n"
+"<code>*</code>  multiplicação\n"
+"<code>/</code>  divisão\n"
+"<code>%</code>  resto da divisão (somente para o tipo <code><a cbot|int>int</a></code>)"
 
 #. type: \t; header
 #: ../E/expr.txt:60
@@ -7549,49 +7615,49 @@ msgid "Real life examples"
 msgstr "Exemplos da vida real"
 
 #. type: \t; header
-#: ../E/expr.txt:82
+#: ../E/expr.txt:81
 #, no-wrap
 msgid "Compound assignment operators"
 msgstr "Operadores de atribuição compostos"
 
 #. type: Plain text
-#: ../E/expr.txt:83
+#: ../E/expr.txt:82
 #, no-wrap
 msgid "Besides the <code>=</code> operator for variable assignment there are several compound-assignment operators."
 msgstr "Além do operador <code>=</code> para atribuição a variáveis, existem muitos outros operadores de atribuição compostos."
 
 #. type: Plain text
-#: ../E/expr.txt:85
+#: ../E/expr.txt:84
 #, no-wrap
 msgid "The compound-assignment operators combine the <code>=</code> assignment operator with another binary operator such as <code>+</code> or <code>-</code>. Compound-assignment operators perform the operation specified by the additional operator and then assign the result to the left operand. For example, a compound-assignment expression such as"
 msgstr "Os operadores de atribuição compostos combinam o operador de atribuição  <code>=</code> com outro operador binário como <code>+</code> ou <code>-</code>. Operadores de atribuição compostos realizam a operação especificada pelo operador adicional e depois atribuem o resultado a esquerda do operador. Por exemplo, uma expressão de atribuição composta como"
 
 #. type: Source code
-#: ../E/expr.txt:86
+#: ../E/expr.txt:85
 #, no-wrap
 msgid "<code>lvalue += expression</code>"
 msgstr "<code>valor-L += expressao</code>"
 
 #. type: Source code
-#: ../E/expr.txt:88
+#: ../E/expr.txt:87
 #, no-wrap
 msgid "<code>lvalue = lvalue + expression</code>"
 msgstr "<code>valor-L = valor-L + expressao</code>"
 
 #. type: \b; header
-#: ../E/expr.txt:97
+#: ../E/expr.txt:96
 #, no-wrap
 msgid "String concatenation"
 msgstr "Concatenação de strings"
 
 #. type: Plain text
-#: ../E/expr.txt:98
+#: ../E/expr.txt:97
 #, no-wrap
 msgid "If at least one of the values used with the <code>+</code> operator is a <a cbot|string>string</a>, then the operation of concatenation is performed. The result of the operator is then a string, which is created by joining end-to-end the string and the other value. If the other value is not a string, then it is converted to string beforehand."
 msgstr "Se pelo menos um dos valores usados com o operador <code>+</code> é uma <a cbot|string>string</a>, então uma operação de concatenação é realizada. O resultado do operador é então uma string, a qual é criada pela junção fim-a-fim da string com o outro valor. Se o outro valor não é uma string, então ela é convertida para string antecipadamente."
 
 #. type: Source code
-#: ../E/expr.txt:102
+#: ../E/expr.txt:101
 #, no-wrap
 msgid ""
 "\tstring s = \"a\" + \"bc\";  // returns \"abc\"\n"
@@ -7605,43 +7671,43 @@ msgstr ""
 "\tstring s = \"a\" + true;  // retorna \"atrue\""
 
 #. type: Plain text
-#: ../E/expr.txt:107
+#: ../E/expr.txt:106
 #, no-wrap
 msgid "Tip: the properties of the concatenation <code>+</code> operator is useful with the <a cbot|message>message();</a> function, because it does not work with other types than string. An empty string can be used together with a value in order to create a string, which actually can be passed to the <a cbot|message>message();</a> function:"
 msgstr "Dica: as propriedades do operador de concatenação <code>+</code> são úteis com a função <a cbot|message>message();</a>, porque ela não funciona com outros tipos que não sejam string. Uma string vazia pode ser utilizada junto com um valor a fim de criar uma string, a qual depois pode ser passada para a função <a cbot|message>message();</a>:"
 
 #. type: \b; header
-#: ../E/expr.txt:178
+#: ../E/expr.txt:177
 #, no-wrap
 msgid "Prefix and postfix increment- and decrement operators"
 msgstr "Operadores de incremento e decremento de prefixo e sufixo"
 
 #. type: Plain text
-#: ../E/expr.txt:181
+#: ../E/expr.txt:180
 #, no-wrap
 msgid "For example to increment the variable <code>a</code> you can write"
 msgstr "Por exemplo, para incrementar a variável <code>a</code> você pode escrever"
 
 #. type: Source code
-#: ../E/expr.txt:182
+#: ../E/expr.txt:181
 #, no-wrap
 msgid "<c/>a++;<n/>"
 msgstr "<c/>a++;<n/>"
 
 #. type: Plain text
-#: ../E/expr.txt:183
+#: ../E/expr.txt:182
 #, no-wrap
 msgid "instead of"
 msgstr "em vez de"
 
 #. type: Source code
-#: ../E/expr.txt:184
+#: ../E/expr.txt:183
 #, no-wrap
 msgid "<c/>a = a + 1;<n/>"
 msgstr "<c/>a = a + 1;<n/>"
 
 #. type: Plain text
-#: ../E/expr.txt:186
+#: ../E/expr.txt:185
 #, no-wrap
 msgid "The result of the operation <code>a++</code> is the value of the variable <code>a</code> *before* the increment. If you use the prefix operator <code>++a</code> the result of the operation is the value of the variable <code>a</code> *after* the increment. The same holds for the <code>--</code> decrement operator."
 msgstr "O resultado da operação <code>a++</code> é o valor da variável <code>a</code> *antes* do incremento. Se você usar o operador prefixo <code>++a</code>, o resultado da operação será o valor da variável <code>a</code> *após* o incremento. O mesmo se aplica ao operador de decremento <code>--</code>."
@@ -7665,7 +7731,41 @@ msgid "Note: it may be not obvious at first, but notice that <code>=</code> is a
 msgstr "Nota: pode não ser óbvio de primeira, porém note que <code>=</code> é um *operador*, não uma instrução. Isto significa que ele pode ser usado no meio de outra expressão! O resultado de <code>=</code> é o valor que está atribuido do lado do valor-L, o resultado da expressão na direita. Exemplo:"
 
 #. type: Source code
-#: ../E/expr.txt:109
+#: ../E/expr.txt:66
+#, no-wrap
+msgid ""
+" int    i = 12 + 3;      // i == 15\n"
+" int    i = 2 - 5;       // i == -3\n"
+" \n"
+" float  f = 3.01 * 10;   // f == 30.1\n"
+" \n"
+" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
+" float  f = 5 / 3;       // f == 1.67\n"
+" float  f = 5 / 0;       // returns an error (division by zero)\n"
+" \n"
+" int    i = 13 % 5;      // i == 3\n"
+" int    i = -8 % 3;      // i == -2\n"
+" \n"
+" float  f = sin(90) * i; // f == -2.0\n"
+" "
+msgstr ""
+" int    i = 12 + 3;      // i == 15\n"
+" int    i = 2 - 5;       // i == -3\n"
+" \n"
+" float  f = 3.01 * 10;   // f == 30.1\n"
+" \n"
+" int    i = 5 / 3;       // i == 1 (conversão automática para int)\n"
+" float  f = 5 / 3;       // f == 1.67\n"
+" float  f = 5 / 0;       // retorna erro (divisão por zero)\n"
+" \n"
+" int    i = 13 % 5;      // i == 3\n"
+" int    i = -8 % 3;      // i == -2\n"
+" \n"
+" float  f = sin(90) * i; // f == -2.0\n"
+" "
+
+#. type: Source code
+#: ../E/expr.txt:108
 #, no-wrap
 msgid ""
 " float pi = 3.14;\n"
@@ -7677,7 +7777,7 @@ msgstr ""
 " message(\"\"+pi);"
 
 #. type: Source code
-#: ../E/expr.txt:190
+#: ../E/expr.txt:189
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -7689,7 +7789,7 @@ msgstr ""
 " // agora b contém 2 e a contém 3"
 
 #. type: Source code
-#: ../E/expr.txt:194
+#: ../E/expr.txt:193
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -7701,25 +7801,25 @@ msgstr ""
 " // agora b contém 3 e a contém 3"
 
 #. type: \b; header
-#: ../E/expr.txt:138
+#: ../E/expr.txt:137
 #, no-wrap
 msgid "Logical operators"
 msgstr "Operadores lógicos"
 
 #. type: Plain text
-#: ../E/expr.txt:139
+#: ../E/expr.txt:138
 #, no-wrap
 msgid "Logical operators work with values of type <a cbot|bool>bool</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr "Operadores lógicos funcionam com valores do tipo <a cbot|bool>bool</a> e eles sempre retorna um  <a cbot|bool>bool</a>. Eles são frequentemente utilizados em  <a cbot|cond>condições</a>."
 
 #. type: \b; header
-#: ../E/expr.txt:151
+#: ../E/expr.txt:150
 #, no-wrap
 msgid "Ternary operator"
 msgstr "Operador ternário"
 
 #. type: Plain text
-#: ../E/expr.txt:152
+#: ../E/expr.txt:151
 #, no-wrap
 msgid ""
 "The ternary operator is nothing more than a syntax sugar. It is also known as \"inline if\". It might be confusing at first, because its syntax is a little more complicated than other operators. It can be described as follows:\n"
@@ -7731,19 +7831,19 @@ msgstr ""
 "Parênteses não são necessários."
 
 #. type: Plain text
-#: ../E/expr.txt:156
+#: ../E/expr.txt:155
 #, no-wrap
 msgid "Firstly, the condition is valued and then the first result is returned if the condition is true, otherwise the second result is returned."
 msgstr "Primeiramente, a condição é avaliada e então o primeiro resultado é retornado se a condição for verdadeira, caso contrário o segundo resultado é retornado."
 
 #. type: \t; header
-#: ../E/expr.txt:158 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
+#: ../E/expr.txt:157 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
 #, no-wrap
 msgid "Example"
 msgstr "Exemplo"
 
 #. type: Source code
-#: ../E/expr.txt:159
+#: ../E/expr.txt:158
 #, no-wrap
 msgid "<c/>float c = ((3.0 > 2.0) ? 10.0 : -10.0); // c == 10.0<n/>"
 msgstr "<c/>float c = ((3.0 > 2.0) ? 10.0 : -10.0); // c == 10.0<n/>"
@@ -7755,19 +7855,19 @@ msgid "A condition is a special <a cbot|expr>expression</a> that returns a <a cb
 msgstr "A condição é uma  <a cbot|expr>expressão</a> especial que retorna um valor <a cbot|bool>booleano</a>, que só pode ser ou <code><a cbot|true>true</a></code> ou <code><a cbot|false>false</a></code>. Com uma condição, você pode escolher, por exemplo, se as instruções em um laço <code><a cbot|while>while</a></code> devem ser repetidas de novo, ou se uma instrução em um bloco <code><a cbot|if>if</a></code> deve ser executada."
 
 #. type: \b; header
-#: ../E/expr.txt:113
+#: ../E/expr.txt:112
 #, no-wrap
 msgid "Comparison operators"
 msgstr "Operadores de comparação"
 
 #. type: Plain text
-#: ../E/expr.txt:114
+#: ../E/expr.txt:113
 #, no-wrap
 msgid "Comparison operators work with values of type <a cbot|bool>float</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr "Operadores de comparação funcionam com valores do tipo <a cbot|bool>float</a> e eles sempre retornam um <a cbot|bool>bool</a>. Eles são frequentemente usados em <a cbot|cond>condições</a>."
 
 #. type: Plain text
-#: ../E/expr.txt:142
+#: ../E/expr.txt:141
 #, no-wrap
 msgid ""
 "<code>!a      </code>not <code>a</code>\n"
@@ -7779,7 +7879,7 @@ msgstr ""
 "<code>a || b  </code><code>a</code> ou <code>b</code>"
 
 #. type: Plain text
-#: ../E/expr.txt:147
+#: ../E/expr.txt:146
 #, no-wrap
 msgid ""
 "<code>!false        </code>returns true\n"
@@ -7791,19 +7891,19 @@ msgstr ""
 "<code>true || false </code>retorna true"
 
 #. type: \b; header
-#: ../E/expr.txt:161
+#: ../E/expr.txt:160
 #, no-wrap
 msgid "Bitwise operators"
 msgstr "Operadores bit a bit"
 
 #. type: Plain text
-#: ../E/expr.txt:162
+#: ../E/expr.txt:161
 #, no-wrap
 msgid "Bitwise operators are similar to the logical operator, because they are operating on bits (which can be only 0 or 1, conditions can have a value only of false or true). So in theory, they should be working with basically any type of variable, because each value in the computer must be stored as a sequence of bits."
 msgstr "Operadores bit a bit são similares aos operadors lógicos, porque eles estão operando em bits (que podem ser somente 0 ou 1, condições só podem ter um valor de falso ou verdadeiro). Então em teoria, eles devem conseguir trabalhar com praticamente qualquer tipo de variável, porque cada valor no computador deve ser armazenado como uma sequência de bits."
 
 #. type: Plain text
-#: ../E/expr.txt:165
+#: ../E/expr.txt:164
 #, no-wrap
 msgid ""
 "<code>a & b  </code><code>a</code> AND <code>b</code>\n"
@@ -7819,7 +7919,7 @@ msgstr ""
 "<code>a << b  </code>desloca bits de a <code>a</code> para a esquerda <code>b</code> vezes"
 
 #. type: Plain text
-#: ../E/expr.txt:172
+#: ../E/expr.txt:171
 #, no-wrap
 msgid ""
 "<code>2 & 1         </code>returns 0\n"
@@ -9388,119 +9488,3 @@ msgid ""
 "     factory(WheeledGrabber, \"program/say-foo.cbot\");\n"
 " }"
 msgstr ""
-
-#. type: Plain text
-#: ../E/expr.txt:54
-#, no-wrap
-msgid ""
-"<code>+</code>  addition\n"
-"<code>-</code>  subtraction\n"
-"<code>*</code>  multiplication\n"
-"<code>/</code>  division\n"
-"<code>%</code>  remainder of the division (works for <code><a cbot|int>int</a></code> as well as <code><a cbot|float>float</a></code>)"
-msgstr ""
-"<code>+</code>  adição\n"
-"<code>-</code>  subtração\n"
-"<code>*</code>  multiplicação\n"
-"<code>/</code>  divisão\n"
-"<code>%</code>  resto da divisão (funciona para <code><a cbot|int>int</a></code>, bem como <code><a cbot|float>float</a></code>)"
-
-#. type: Source code
-#: ../E/expr.txt:66
-#, no-wrap
-msgid ""
-" int    i = 12 + 3;      // i == 15\n"
-" int    i = 2 - 5;       // i == -3\n"
-" \n"
-" float  f = 3.01 * 10;   // f == 30.1\n"
-" \n"
-" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
-" float  f = 5 / 3;       // f == 1.67\n"
-" float  f = 5 / 0;       // returns an error (division by zero)\n"
-" \n"
-" int    i = 13 % 5;      // i == 3\n"
-" int    i = -8 % 3;      // i == -2\n"
-" float  f = -4.5 % 2.75; // f == -1.75\n"
-" \n"
-" float  f = sin(90) * i; // f == -2.0\n"
-" "
-msgstr ""
-" int    i = 12 + 3;      // i == 15\n"
-" int    i = 2 - 5;       // i == -3\n"
-" \n"
-" float  f = 3.01 * 10;   // f == 30.1\n"
-" \n"
-" int    i = 5 / 3;       // i == 1 (conversão automática para int)\n"
-" float  f = 5 / 3;       // f == 1.67\n"
-" float  f = 5 / 0;       // retorna erro (divisão por zero)\n"
-" \n"
-" int    i = 13 % 5;      // i == 3\n"
-" int    i = -8 % 3;      // i == -2\n"
-" float  f = -4.5 % 2.75; // f == -1.75\n"
-" \n"
-" float  f = sin(90) * i; // f == -2.0\n"
-" "
-
-#. type: Plain text
-#: ../E/expr.txt:91
-#, no-wrap
-msgid ""
-"<code>+=</code>  addition\n"
-"<code>-=</code>  subtraction\n"
-"<code>*=</code>  multiplication\n"
-"<code>/=</code>  division\n"
-"<code>%=</code>  remainder of the division"
-msgstr ""
-"<code>+=</code>  adição\n"
-"<code>-=</code>  subtração\n"
-"<code>*=</code>  multiplicação\n"
-"<code>/=</code>  divisão\n"
-"<code>%=</code>  resto da divisão"
-
-#. type: Plain text
-#: ../E/object.txt:4
-#, no-wrap
-msgid ""
-"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
-"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
-"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
-"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
-"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
-"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
-"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
-"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
-"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
-"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
-"<code>object object.energyCell   </code>Power cell on the bot\n"
-"<code>object object.load         </code>Object carried by the bot\n"
-"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
-"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object\n"
-"<code><a cbot|bool>bool</a>   object.dead         </code>Is the object dead?"
-msgstr ""
-"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Categoria</a> do objeto\n"
-"<code><a cbot|point>point</a>  object.position     </code>Posição do objeto (x,y,z)\n"
-"<code><a cbot|float>float</a>  object.orientation  </code>Orientação do objeto (0..360)\n"
-"<code><a cbot|float>float</a>  object.pitch        </code>Ângulo de avanço / retrocesso do objeto\n"
-"<code><a cbot|float>float</a>  object.roll         </code>Ângulo direito / esquerdo do objeto \n"
-"<code><a cbot|float>float</a>  object.energyLevel  </code>Nível de energia (0..1)\n"
-"<code><a cbot|float>float</a>  object.shieldLevel  </code>Nível do escudo (0..1)\n"
-"<code><a cbot|float>float</a>  object.temperature  </code>Temperatura do jato (0..1)\n"
-"<code><a cbot|float>float</a>  object.altitude     </code>Altitude acima do chão\n"
-"<code><a cbot|float>float</a>  object.lifeTime     </code>Tempo de vida do objeto\n"
-"<code>object object.energyCell   </code>Célula de energia do robô\n"
-"<code>object object.load         </code>Objeto carregado pelo robô\n"
-"<code><a cbot|int>int</a>    object.team         </code>A equipe do objeto (veja <a battles>códigos de batalhas</a>)\n"
-"<code><a cbot|point>point</a>  object.velocity     </code>Velocidade do objeto\n"
-"<code><a cbot|bool>bool</a>   object.dead         </code>O objeto está morto?"
-
-#. type: Source code
-#: ../E/object.txt:67
-#, no-wrap
-msgid "<code>dead</code>"
-msgstr ""
-
-#. type: Plain text
-#: ../E/object.txt:68
-#, no-wrap
-msgid "True if the object was recently killed (while the death animation is playing). Note that accessing this property or any other property after the death animation finishes will cause an error that stops the program."
-msgstr "True se o objeto foi morto recentemente (enquanto a animação de morte está sendo reproduzida). Observe que acessar essa propriedade ou qualquer outra propriedade após a conclusão da animação de morte causará um erro que interromperá o programa."

--- a/help/cbot/po/pt.po
+++ b/help/cbot/po/pt.po
@@ -53,13 +53,13 @@ msgid "Time in seconds."
 msgstr "Tempo em segundos."
 
 #. type: \t; header
-#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:197 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:79 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
+#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:198 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:83 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
 #, no-wrap
 msgid "See also"
 msgstr "Veja também"
 
 #. type: Plain text
-#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:198 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:80 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
+#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:199 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:84 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
 #, no-wrap
 msgid "<a cbot>Programming</a>, <a cbot|type>types</a> and <a cbot|category>categories</a>."
 msgstr "<a cbot>Programação</a>, <a cbot|type>tipos</a> e <a cbot|category>categorias</a>."
@@ -615,7 +615,7 @@ msgid "Conditions"
 msgstr "Condições"
 
 #. type: Plain text
-#: ../E/expr.txt:116
+#: ../E/expr.txt:117
 #, no-wrap
 msgid ""
 "<code>a == b  </code><code>a</code> equals <code>b</code>\n"
@@ -633,7 +633,7 @@ msgstr ""
 "<code>a >= b  </code><code>a</code> é maior ou igual a <code>b</code>"
 
 #. type: Plain text
-#: ../E/expr.txt:124
+#: ../E/expr.txt:125
 #, no-wrap
 msgid ""
 "<code>12 == 12  </code>returns true\n"
@@ -651,13 +651,13 @@ msgstr ""
 "<code>12 >= 12  </code>retorna true "
 
 #. type: Plain text
-#: ../E/expr.txt:132
+#: ../E/expr.txt:133
 #, no-wrap
 msgid "Be careful not to confuse the equality comparison <code>==</code> with the assignment of a <a cbot|var>variable</a> <code>=</code>."
 msgstr "Tenha cuidado para não confundir o operador de comparação <code>==</code> com o operadoratribuição de valor a <a cbot|var>variáveis</a> <code>=</code>."
 
 #. type: Plain text
-#: ../E/expr.txt:134
+#: ../E/expr.txt:135
 #, no-wrap
 msgid ""
 "<code>a == b</code> is an expression that compares <code>a</code> with <code>b</code>.\n"
@@ -1263,29 +1263,13 @@ msgid "Expressions"
 msgstr "Expressões"
 
 #. type: Plain text
-#: ../E/expr.txt:86
+#: ../E/expr.txt:87
 #, no-wrap
 msgid "is equivalent to"
 msgstr "é equivalente a"
 
 #. type: Plain text
-#: ../E/expr.txt:90
-#, no-wrap
-msgid ""
-"<code>+=</code>  addition\n"
-"<code>-=</code>  subtraction\n"
-"<code>*=</code>  multiplication\n"
-"<code>/=</code>  division\n"
-"<code>%=</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
-msgstr ""
-"<code>+=</code>  adição\n"
-"<code>-=</code>  subtração\n"
-"<code>*=</code>  multiplicação\n"
-"<code>/=</code>  divisão\n"
-"<code>%=</code>  resto da divisão (somente para o tipo <code><a cbot|int>int</a></code>)"
-
-#. type: Plain text
-#: ../E/expr.txt:178
+#: ../E/expr.txt:179
 #, no-wrap
 msgid "The operators <code>++</code> and <code>--</code> allow you to increment (++) or to decrement (--) a variable in very compact and efficient manner."
 msgstr "Os operadores <code>++</code> e <code>--</code> permitem a você incrementar (++)ou decrementar (--) uma variável de uma maneira bem compacta e eficiente."
@@ -2431,79 +2415,79 @@ msgid "Type <code>object</code>"
 msgstr "Tipo <code>object</code>"
 
 #. type: Source code
-#: ../E/object.txt:21
+#: ../E/object.txt:22
 #, no-wrap
 msgid "<code>category</code>"
 msgstr "<code>category</code>"
 
 #. type: Source code
-#: ../E/object.txt:24
+#: ../E/object.txt:25
 #, no-wrap
 msgid "<code>position</code>"
 msgstr "<code>position</code>"
 
 #. type: Plain text
-#: ../E/object.txt:25
+#: ../E/object.txt:26
 #, no-wrap
 msgid "Position of the object on the planet, in meters. The coordinates <code>x</code> and <code>y</code> correspond to the location on a map, the <code>z</code> coordinate corresponds to the altitude above (respectively below) sea level. "
 msgstr "Posição do objeto no planeta, em metros. As coordenadas <code>x</code> e <code>y</code> correspondem ao local no mapa, a coordenada <code>z</code> corresponde a altitude acima (respectivamente abaixo) no nível do mar."
 
 #. type: Source code
-#: ../E/object.txt:27
+#: ../E/object.txt:28
 #, no-wrap
 msgid "<code>orientation</code>"
 msgstr "<code>orientation</code>"
 
 #. type: Plain text
-#: ../E/object.txt:28
+#: ../E/object.txt:29
 #, no-wrap
 msgid "Orientation of the object, in degrees. The orientation tells you what direction the object is facing. An orientation of <code>0</code> corresponds to an object facing eastwards, thus following the positive <code>x</code> axis. The orientation is measured counterclockwise. "
 msgstr "Orientação do objeto, em graus. A orientação diz a você qual a direção que o objeto está apontando. Uma orientação de <code>0</code>corresponde a um objeto virado para o leste, sendo assim, seguindo o eixo positivo <code>x</code>. A orientação é medida em sentido anti-horário. "
 
 #. type: Source code
-#: ../E/object.txt:30
+#: ../E/object.txt:31
 #, no-wrap
 msgid "<code>pitch</code>"
 msgstr "<code>pitch</code>"
 
 #. type: Plain text
-#: ../E/object.txt:31
+#: ../E/object.txt:32
 #, no-wrap
 msgid "Forward/backward angle of the robot. A pitch of <code>0</code> means that the bot is standing on flat ground. A positive inclination means that it is facing upwards, a negative inclination means that it is facing downwards. "
 msgstr "Ângulo para frente / para trás do robô. Um pitch de <code>0</code> significa que o robô está em solo plano. Uma inclinação positiva significa que ele está olhando para cima, uma inclinação negativa significa que ele está olhando para baixo."
 
 #. type: Source code
-#: ../E/object.txt:33
+#: ../E/object.txt:34
 #, no-wrap
 msgid "<code>roll</code>"
 msgstr "<code>roll</code>"
 
 #. type: Plain text
-#: ../E/object.txt:34
+#: ../E/object.txt:35
 #, no-wrap
 msgid "Left/right angle of the bot, in degrees. A positive value means that the bot is leaning to the left side, a negative value means that it is leaning to the right side. "
 msgstr "Ângulo direito / esquerdo do robô, em graus. Um valor positivo significa que o robô está inclinado para o lado esquerdo, um valor negativo significa que o robô está inclinado para o lado direito."
 
 #. type: Source code
-#: ../E/object.txt:36
+#: ../E/object.txt:37
 #, no-wrap
 msgid "<code>energyLevel</code>"
 msgstr "<code>energyLevel</code>"
 
 #. type: Plain text
-#: ../E/object.txt:37
+#: ../E/object.txt:38
 #, no-wrap
 msgid "Energy level, between 0 and 1. A normal <a object|power>power cell</a> that is fully charged returns the value <code>1</code>. A <a object|atomic>nuclear power cell</a> never returns a value higher than 1, it just lasts longer. Attention: The energy level of a bot is always zero, because the energy is not contained in the bot, but in the power cell. To know the energy level of the power cell of a bot, you must write <code>energyCell.energyLevel</code>. "
 msgstr "Nível de energia, entre 0 e 1. Uma <a object|power>célula de energia</a> normal que está totalmente carregada retorna o valor <code>1</code>. Uma <a object|atomic>célula de energia nuclear</a>  nunca retorna um valor maior que 1, ela apenas dura mais. Atenção: o nível de energia de um robô é sempre zero, porque a energia não está no robô, mas sim na célula de energia. Para saber o nível de energia que resta na célula de um robô, você deve escrever <code>energyCell.energyLevel</code>. "
 
 #. type: Source code
-#: ../E/object.txt:39
+#: ../E/object.txt:40
 #, no-wrap
 msgid "<code>shieldLevel</code>"
 msgstr "<code>shieldLevel</code>"
 
 #. type: Plain text
-#: ../E/object.txt:40
+#: ../E/object.txt:41
 #, no-wrap
 msgid ""
 "Shield level of a robot or building. A level <code>1</code> indicates that the shield is still perfect. Every time that the bot or building gets a bullet or collides with another object, the shield level decreases. When the level reaches <code>0</code>, the next bullet or collision will destroy the bot or building. \n"
@@ -2513,49 +2497,49 @@ msgstr ""
 "Robôs podem reenergizar seus escudos em um <a object|repair>centro de reparo</a>. O escudo de um edifício é reparado se ele estiver dentro da esfera de proteção de um  <a object|botshld>protetor</a>."
 
 #. type: Source code
-#: ../E/object.txt:43
+#: ../E/object.txt:44
 #, no-wrap
 msgid "<code>temperature</code>"
 msgstr "<code>temperature</code>"
 
 #. type: Plain text
-#: ../E/object.txt:44
+#: ../E/object.txt:45
 #, no-wrap
 msgid "Temperature of the jet of <a object|botgj>winged bots</a>. <code>0</code> corresponds to a cold jet. When used, the temperature increases progressively. When it reaches the value <code>1</code>, the jet is overheated and stops working, until it cooled down a little. "
 msgstr "Temperatura do jato de <a object|botgj>robôs alados</a>. <code>0</code> corresponde a um jato frio. Quando usado, a temperatura aumenta progressivamente. Quando ela atinge o valor <code>1</code>, o jato está superaquecido e para de funcionar, até que ele esfrie um pouco."
 
 #. type: Source code
-#: ../E/object.txt:46
+#: ../E/object.txt:47
 #, no-wrap
 msgid "<code>altitude</code>"
 msgstr "<code>altitude</code>"
 
 #. type: Plain text
-#: ../E/object.txt:47
+#: ../E/object.txt:48
 #, no-wrap
 msgid "The <code>z</code> coordinate of the position indicates the altitude above sea level, whereas the <code>altitude</code> indicates the height above ground. This value is meaningful only for <a object|botgj>winged bots</a> and for <a object|wasp>wasps</a>. For all other objects, this value is zero. "
 msgstr "A coordenada <code>z</code> da posição indica a altitude acima do nível do mar, enquando a  <code>altitude</code> indica a altura acima do chão. Este valor só é útil para <a object|botgj>robôs alados</a> e para <a object|wasp>vespas</a>.  Para todos os outros objetos, este valor é zero."
 
 #. type: Source code
-#: ../E/object.txt:49
+#: ../E/object.txt:50
 #, no-wrap
 msgid "<code>lifeTime</code>"
 msgstr "<code>lifeTime</code>"
 
 #. type: Plain text
-#: ../E/object.txt:50
+#: ../E/object.txt:51
 #, no-wrap
 msgid "The age of the object in seconds since it's creation."
 msgstr "A idade de um objeto em segundos desde a sua criação."
 
 #. type: Source code
-#: ../E/object.txt:52
+#: ../E/object.txt:53
 #, no-wrap
 msgid "<code>energyCell</code>"
 msgstr "<code>energyCell</code>"
 
 #. type: Plain text
-#: ../E/object.txt:53
+#: ../E/object.txt:54
 #, no-wrap
 msgid ""
 "This information is special, because it returns the information about another object, in this case the power pack. This means that energyCell contains all the characteristics of a normal object, for example <code>category</code> (PowerCell or NuclearCell), <code>position</code> (the position of the cell), etc.\n"
@@ -2567,31 +2551,31 @@ msgstr ""
 "Se o robô não tiver uma célula de energia, <code>energyCell</code> retorna <code>null</code>."
 
 #. type: Source code
-#: ../E/object.txt:57
+#: ../E/object.txt:58
 #, no-wrap
 msgid "<code>load</code>"
 msgstr "<code>load</code>"
 
 #. type: Plain text
-#: ../E/object.txt:58
+#: ../E/object.txt:59
 #, no-wrap
 msgid "This information also returns the description of a whole object: the description of the object carried by a <a object|botgr>grabber</a>. If it carries nothing, <code>load</code> returns <code>null</code>."
 msgstr "Esta informação também retorna a descrição de um objeto completo: a descrição do objeto carregado por um <a object|botgr>agarrador</a>. Se ele não carrega nada, <code>load</code> retorna <code>null</code>."
 
 #. type: \t; header, \b; header
-#: ../E/expr.txt:99 ../E/expr.txt:123 ../E/expr.txt:145 ../E/expr.txt:170 ../E/expr.txt:187 ../E/factory.txt:21 ../E/object.txt:66
+#: ../E/expr.txt:100 ../E/expr.txt:124 ../E/expr.txt:146 ../E/expr.txt:171 ../E/expr.txt:188 ../E/factory.txt:21 ../E/object.txt:70
 #, no-wrap
 msgid "Examples"
 msgstr "Exemplos"
 
 #. type: Plain text
-#: ../E/object.txt:67
+#: ../E/object.txt:71
 #, no-wrap
 msgid "The type <code>object</code> returns the special value <code><a cbot|null>null</a></code> when the object does not exist. For example:"
 msgstr "O tipo <code>object</code> retorna o valor especial <code><a cbot|null>null</a></code>quando o objeto não existe. Por exemplo:"
 
 #. type: Source code
-#: ../E/object.txt:69
+#: ../E/object.txt:73
 #, no-wrap
 msgid ""
 "\tobject a;\n"
@@ -3223,7 +3207,7 @@ msgid "Returns the first object found that corresponds to the specified category
 msgstr "Retorna o primeiro objeto encontrado que corresponda a categoria na zona especificada. Se nenhum objeto for encontrado, retorna o valor <code><a cbot|null>null</a></code>."
 
 #. type: \t; header
-#: ../E/expr.txt:131 ../E/radar.txt:68
+#: ../E/expr.txt:132 ../E/radar.txt:68
 #, no-wrap
 msgid "Remark"
 msgstr "Observação"
@@ -6505,71 +6489,37 @@ msgid "Use this type for variables that contain the characteristics of an object
 msgstr "Use este tipo para variáveis que contém as características de um objeto, seja ele um robô, um edifício, alguma matéria prima, um inimigo, etc. Aqui estão todas as propriedades de um objeto:"
 
 #. type: Plain text
-#: ../E/object.txt:4
-#, no-wrap
-msgid ""
-"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
-"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
-"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
-"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
-"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
-"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
-"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
-"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
-"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
-"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
-"<code>object object.energyCell   </code>Power cell on the bot\n"
-"<code>object object.load         </code>Object carried by the bot\n"
-"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
-"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object"
-msgstr ""
-"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Categoria</a> do objeto\n"
-"<code><a cbot|point>point</a>  object.position     </code>Posição do objeto (x,y,z)\n"
-"<code><a cbot|float>float</a>  object.orientation  </code>Orientação do objeto (0..360)\n"
-"<code><a cbot|float>float</a>  object.pitch        </code>Ângulo de avanço / retrocesso do objeto\n"
-"<code><a cbot|float>float</a>  object.roll         </code>Ângulo direito / esquerdo do objeto \n"
-"<code><a cbot|float>float</a>  object.energyLevel  </code>Nível de energia (0..1)\n"
-"<code><a cbot|float>float</a>  object.shieldLevel  </code>Nível do escudo (0..1)\n"
-"<code><a cbot|float>float</a>  object.temperature  </code>Temperatura do jato (0..1)\n"
-"<code><a cbot|float>float</a>  object.altitude     </code>Altitude acima do chão\n"
-"<code><a cbot|float>float</a>  object.lifeTime     </code>Tempo de vida do objeto\n"
-"<code>object object.energyCell   </code>Célula de energia do robô\n"
-"<code>object object.load         </code>Objeto carregado pelo robô\n"
-"<code><a cbot|int>int</a>    object.team         </code>A equipe do objeto (veja <a battles>códigos de batalhas</a>)\n"
-"<code><a cbot|point>point</a>  object.velocity     </code>Velocidade do objeto"
-
-#. type: Plain text
-#: ../E/object.txt:19
+#: ../E/object.txt:20
 #, no-wrap
 msgid "Also, some objects have additional methods (instructions). See them in <a cbot>the main list</a> in the <c/>\"Instructions specific for some objects\" section."
 msgstr "Além diso, alguns objetos possuem métodos adicionais (instruções). Veja eles na <a cbot>lista principal</a>, na seção <c/>\"Instruções especificas para alguns objetos\"."
 
 #. type: Plain text
-#: ../E/object.txt:22
+#: ../E/object.txt:23
 #, no-wrap
 msgid "The <n/><a cbot|category>category</a> of an object allows you to know what it is, f. ex. what kind of bot, building, enemy, etc."
 msgstr "A <n/><a cbot|category>categoria</a> de um objeto permite a você conhecer o que ele é, por exemplo, qual tipo de robô, edifício, inimigo, etc."
 
 #. type: Source code
-#: ../E/object.txt:60
+#: ../E/object.txt:61
 #, no-wrap
 msgid "<code>team</code>"
 msgstr "<code>team</code>"
 
 #. type: Plain text
-#: ../E/object.txt:61
+#: ../E/object.txt:62
 #, no-wrap
 msgid "The bot's team. Used in <a battles>code battles</a>. If the object has no team assigned (e.g. in no team-based levels, the object being a resource), this is equal to <code>0</code>."
 msgstr "A equipe do robô. Usada em <a battles>batalhas de código</a>. Se o objeto não tem equipe atribuída (isto é, em nenhum nível de equipe, o objeto sendo um recurso), isto é igual a <code>0</code>."
 
 #. type: Source code
-#: ../E/object.txt:63
+#: ../E/object.txt:64
 #, no-wrap
 msgid "<code>velocity</code>"
 msgstr "<code>velocity</code>"
 
 #. type: Plain text
-#: ../E/object.txt:64
+#: ../E/object.txt:65
 #, no-wrap
 msgid "Current velocity of the object. Should be treated as a three-dimensional vector."
 msgstr "Velocidade atual do objeto. Deve ser tratada como um vetor de três dimensões."
@@ -7569,26 +7519,10 @@ msgid "Binary operators below are working with fundamental number types (<code><
 msgstr "As operações binárias abaixo funcionam com os tipos numéricos fundamentais (<code><a cbot|int>int</a></code>, <code><a cbot|float>float</a></code>)."
 
 #. type: \t; header
-#: ../E/expr.txt:53 ../E/expr.txt:89 ../E/expr.txt:115 ../E/expr.txt:140 ../E/expr.txt:163
+#: ../E/expr.txt:53 ../E/expr.txt:90 ../E/expr.txt:116 ../E/expr.txt:141 ../E/expr.txt:164
 #, no-wrap
 msgid "List"
 msgstr "Lista"
-
-#. type: Plain text
-#: ../E/expr.txt:54
-#, no-wrap
-msgid ""
-"<code>+</code>  addition\n"
-"<code>-</code>  subtraction\n"
-"<code>*</code>  multiplication\n"
-"<code>/</code>  division\n"
-"<code>%</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
-msgstr ""
-"<code>+</code>  adição\n"
-"<code>-</code>  subtração\n"
-"<code>*</code>  multiplicação\n"
-"<code>/</code>  divisão\n"
-"<code>%</code>  resto da divisão (somente para o tipo <code><a cbot|int>int</a></code>)"
 
 #. type: \t; header
 #: ../E/expr.txt:60
@@ -7615,49 +7549,49 @@ msgid "Real life examples"
 msgstr "Exemplos da vida real"
 
 #. type: \t; header
-#: ../E/expr.txt:81
+#: ../E/expr.txt:82
 #, no-wrap
 msgid "Compound assignment operators"
 msgstr "Operadores de atribuição compostos"
 
 #. type: Plain text
-#: ../E/expr.txt:82
+#: ../E/expr.txt:83
 #, no-wrap
 msgid "Besides the <code>=</code> operator for variable assignment there are several compound-assignment operators."
 msgstr "Além do operador <code>=</code> para atribuição a variáveis, existem muitos outros operadores de atribuição compostos."
 
 #. type: Plain text
-#: ../E/expr.txt:84
+#: ../E/expr.txt:85
 #, no-wrap
 msgid "The compound-assignment operators combine the <code>=</code> assignment operator with another binary operator such as <code>+</code> or <code>-</code>. Compound-assignment operators perform the operation specified by the additional operator and then assign the result to the left operand. For example, a compound-assignment expression such as"
 msgstr "Os operadores de atribuição compostos combinam o operador de atribuição  <code>=</code> com outro operador binário como <code>+</code> ou <code>-</code>. Operadores de atribuição compostos realizam a operação especificada pelo operador adicional e depois atribuem o resultado a esquerda do operador. Por exemplo, uma expressão de atribuição composta como"
 
 #. type: Source code
-#: ../E/expr.txt:85
+#: ../E/expr.txt:86
 #, no-wrap
 msgid "<code>lvalue += expression</code>"
 msgstr "<code>valor-L += expressao</code>"
 
 #. type: Source code
-#: ../E/expr.txt:87
+#: ../E/expr.txt:88
 #, no-wrap
 msgid "<code>lvalue = lvalue + expression</code>"
 msgstr "<code>valor-L = valor-L + expressao</code>"
 
 #. type: \b; header
-#: ../E/expr.txt:96
+#: ../E/expr.txt:97
 #, no-wrap
 msgid "String concatenation"
 msgstr "Concatenação de strings"
 
 #. type: Plain text
-#: ../E/expr.txt:97
+#: ../E/expr.txt:98
 #, no-wrap
 msgid "If at least one of the values used with the <code>+</code> operator is a <a cbot|string>string</a>, then the operation of concatenation is performed. The result of the operator is then a string, which is created by joining end-to-end the string and the other value. If the other value is not a string, then it is converted to string beforehand."
 msgstr "Se pelo menos um dos valores usados com o operador <code>+</code> é uma <a cbot|string>string</a>, então uma operação de concatenação é realizada. O resultado do operador é então uma string, a qual é criada pela junção fim-a-fim da string com o outro valor. Se o outro valor não é uma string, então ela é convertida para string antecipadamente."
 
 #. type: Source code
-#: ../E/expr.txt:101
+#: ../E/expr.txt:102
 #, no-wrap
 msgid ""
 "\tstring s = \"a\" + \"bc\";  // returns \"abc\"\n"
@@ -7671,43 +7605,43 @@ msgstr ""
 "\tstring s = \"a\" + true;  // retorna \"atrue\""
 
 #. type: Plain text
-#: ../E/expr.txt:106
+#: ../E/expr.txt:107
 #, no-wrap
 msgid "Tip: the properties of the concatenation <code>+</code> operator is useful with the <a cbot|message>message();</a> function, because it does not work with other types than string. An empty string can be used together with a value in order to create a string, which actually can be passed to the <a cbot|message>message();</a> function:"
 msgstr "Dica: as propriedades do operador de concatenação <code>+</code> são úteis com a função <a cbot|message>message();</a>, porque ela não funciona com outros tipos que não sejam string. Uma string vazia pode ser utilizada junto com um valor a fim de criar uma string, a qual depois pode ser passada para a função <a cbot|message>message();</a>:"
 
 #. type: \b; header
-#: ../E/expr.txt:177
+#: ../E/expr.txt:178
 #, no-wrap
 msgid "Prefix and postfix increment- and decrement operators"
 msgstr "Operadores de incremento e decremento de prefixo e sufixo"
 
 #. type: Plain text
-#: ../E/expr.txt:180
+#: ../E/expr.txt:181
 #, no-wrap
 msgid "For example to increment the variable <code>a</code> you can write"
 msgstr "Por exemplo, para incrementar a variável <code>a</code> você pode escrever"
 
 #. type: Source code
-#: ../E/expr.txt:181
+#: ../E/expr.txt:182
 #, no-wrap
 msgid "<c/>a++;<n/>"
 msgstr "<c/>a++;<n/>"
 
 #. type: Plain text
-#: ../E/expr.txt:182
+#: ../E/expr.txt:183
 #, no-wrap
 msgid "instead of"
 msgstr "em vez de"
 
 #. type: Source code
-#: ../E/expr.txt:183
+#: ../E/expr.txt:184
 #, no-wrap
 msgid "<c/>a = a + 1;<n/>"
 msgstr "<c/>a = a + 1;<n/>"
 
 #. type: Plain text
-#: ../E/expr.txt:185
+#: ../E/expr.txt:186
 #, no-wrap
 msgid "The result of the operation <code>a++</code> is the value of the variable <code>a</code> *before* the increment. If you use the prefix operator <code>++a</code> the result of the operation is the value of the variable <code>a</code> *after* the increment. The same holds for the <code>--</code> decrement operator."
 msgstr "O resultado da operação <code>a++</code> é o valor da variável <code>a</code> *antes* do incremento. Se você usar o operador prefixo <code>++a</code>, o resultado da operação será o valor da variável <code>a</code> *após* o incremento. O mesmo se aplica ao operador de decremento <code>--</code>."
@@ -7731,41 +7665,7 @@ msgid "Note: it may be not obvious at first, but notice that <code>=</code> is a
 msgstr "Nota: pode não ser óbvio de primeira, porém note que <code>=</code> é um *operador*, não uma instrução. Isto significa que ele pode ser usado no meio de outra expressão! O resultado de <code>=</code> é o valor que está atribuido do lado do valor-L, o resultado da expressão na direita. Exemplo:"
 
 #. type: Source code
-#: ../E/expr.txt:66
-#, no-wrap
-msgid ""
-" int    i = 12 + 3;      // i == 15\n"
-" int    i = 2 - 5;       // i == -3\n"
-" \n"
-" float  f = 3.01 * 10;   // f == 30.1\n"
-" \n"
-" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
-" float  f = 5 / 3;       // f == 1.67\n"
-" float  f = 5 / 0;       // returns an error (division by zero)\n"
-" \n"
-" int    i = 13 % 5;      // i == 3\n"
-" int    i = -8 % 3;      // i == -2\n"
-" \n"
-" float  f = sin(90) * i; // f == -2.0\n"
-" "
-msgstr ""
-" int    i = 12 + 3;      // i == 15\n"
-" int    i = 2 - 5;       // i == -3\n"
-" \n"
-" float  f = 3.01 * 10;   // f == 30.1\n"
-" \n"
-" int    i = 5 / 3;       // i == 1 (conversão automática para int)\n"
-" float  f = 5 / 3;       // f == 1.67\n"
-" float  f = 5 / 0;       // retorna erro (divisão por zero)\n"
-" \n"
-" int    i = 13 % 5;      // i == 3\n"
-" int    i = -8 % 3;      // i == -2\n"
-" \n"
-" float  f = sin(90) * i; // f == -2.0\n"
-" "
-
-#. type: Source code
-#: ../E/expr.txt:108
+#: ../E/expr.txt:109
 #, no-wrap
 msgid ""
 " float pi = 3.14;\n"
@@ -7777,7 +7677,7 @@ msgstr ""
 " message(\"\"+pi);"
 
 #. type: Source code
-#: ../E/expr.txt:189
+#: ../E/expr.txt:190
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -7789,7 +7689,7 @@ msgstr ""
 " // agora b contém 2 e a contém 3"
 
 #. type: Source code
-#: ../E/expr.txt:193
+#: ../E/expr.txt:194
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -7801,25 +7701,25 @@ msgstr ""
 " // agora b contém 3 e a contém 3"
 
 #. type: \b; header
-#: ../E/expr.txt:137
+#: ../E/expr.txt:138
 #, no-wrap
 msgid "Logical operators"
 msgstr "Operadores lógicos"
 
 #. type: Plain text
-#: ../E/expr.txt:138
+#: ../E/expr.txt:139
 #, no-wrap
 msgid "Logical operators work with values of type <a cbot|bool>bool</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr "Operadores lógicos funcionam com valores do tipo <a cbot|bool>bool</a> e eles sempre retorna um  <a cbot|bool>bool</a>. Eles são frequentemente utilizados em  <a cbot|cond>condições</a>."
 
 #. type: \b; header
-#: ../E/expr.txt:150
+#: ../E/expr.txt:151
 #, no-wrap
 msgid "Ternary operator"
 msgstr "Operador ternário"
 
 #. type: Plain text
-#: ../E/expr.txt:151
+#: ../E/expr.txt:152
 #, no-wrap
 msgid ""
 "The ternary operator is nothing more than a syntax sugar. It is also known as \"inline if\". It might be confusing at first, because its syntax is a little more complicated than other operators. It can be described as follows:\n"
@@ -7831,19 +7731,19 @@ msgstr ""
 "Parênteses não são necessários."
 
 #. type: Plain text
-#: ../E/expr.txt:155
+#: ../E/expr.txt:156
 #, no-wrap
 msgid "Firstly, the condition is valued and then the first result is returned if the condition is true, otherwise the second result is returned."
 msgstr "Primeiramente, a condição é avaliada e então o primeiro resultado é retornado se a condição for verdadeira, caso contrário o segundo resultado é retornado."
 
 #. type: \t; header
-#: ../E/expr.txt:157 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
+#: ../E/expr.txt:158 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
 #, no-wrap
 msgid "Example"
 msgstr "Exemplo"
 
 #. type: Source code
-#: ../E/expr.txt:158
+#: ../E/expr.txt:159
 #, no-wrap
 msgid "<c/>float c = ((3.0 > 2.0) ? 10.0 : -10.0); // c == 10.0<n/>"
 msgstr "<c/>float c = ((3.0 > 2.0) ? 10.0 : -10.0); // c == 10.0<n/>"
@@ -7855,19 +7755,19 @@ msgid "A condition is a special <a cbot|expr>expression</a> that returns a <a cb
 msgstr "A condição é uma  <a cbot|expr>expressão</a> especial que retorna um valor <a cbot|bool>booleano</a>, que só pode ser ou <code><a cbot|true>true</a></code> ou <code><a cbot|false>false</a></code>. Com uma condição, você pode escolher, por exemplo, se as instruções em um laço <code><a cbot|while>while</a></code> devem ser repetidas de novo, ou se uma instrução em um bloco <code><a cbot|if>if</a></code> deve ser executada."
 
 #. type: \b; header
-#: ../E/expr.txt:112
+#: ../E/expr.txt:113
 #, no-wrap
 msgid "Comparison operators"
 msgstr "Operadores de comparação"
 
 #. type: Plain text
-#: ../E/expr.txt:113
+#: ../E/expr.txt:114
 #, no-wrap
 msgid "Comparison operators work with values of type <a cbot|bool>float</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr "Operadores de comparação funcionam com valores do tipo <a cbot|bool>float</a> e eles sempre retornam um <a cbot|bool>bool</a>. Eles são frequentemente usados em <a cbot|cond>condições</a>."
 
 #. type: Plain text
-#: ../E/expr.txt:141
+#: ../E/expr.txt:142
 #, no-wrap
 msgid ""
 "<code>!a      </code>not <code>a</code>\n"
@@ -7879,7 +7779,7 @@ msgstr ""
 "<code>a || b  </code><code>a</code> ou <code>b</code>"
 
 #. type: Plain text
-#: ../E/expr.txt:146
+#: ../E/expr.txt:147
 #, no-wrap
 msgid ""
 "<code>!false        </code>returns true\n"
@@ -7891,19 +7791,19 @@ msgstr ""
 "<code>true || false </code>retorna true"
 
 #. type: \b; header
-#: ../E/expr.txt:160
+#: ../E/expr.txt:161
 #, no-wrap
 msgid "Bitwise operators"
 msgstr "Operadores bit a bit"
 
 #. type: Plain text
-#: ../E/expr.txt:161
+#: ../E/expr.txt:162
 #, no-wrap
 msgid "Bitwise operators are similar to the logical operator, because they are operating on bits (which can be only 0 or 1, conditions can have a value only of false or true). So in theory, they should be working with basically any type of variable, because each value in the computer must be stored as a sequence of bits."
 msgstr "Operadores bit a bit são similares aos operadors lógicos, porque eles estão operando em bits (que podem ser somente 0 ou 1, condições só podem ter um valor de falso ou verdadeiro). Então em teoria, eles devem conseguir trabalhar com praticamente qualquer tipo de variável, porque cada valor no computador deve ser armazenado como uma sequência de bits."
 
 #. type: Plain text
-#: ../E/expr.txt:164
+#: ../E/expr.txt:165
 #, no-wrap
 msgid ""
 "<code>a & b  </code><code>a</code> AND <code>b</code>\n"
@@ -7919,7 +7819,7 @@ msgstr ""
 "<code>a << b  </code>desloca bits de a <code>a</code> para a esquerda <code>b</code> vezes"
 
 #. type: Plain text
-#: ../E/expr.txt:171
+#: ../E/expr.txt:172
 #, no-wrap
 msgid ""
 "<code>2 & 1         </code>returns 0\n"
@@ -9487,4 +9387,80 @@ msgid ""
 " {\n"
 "     factory(WheeledGrabber, \"program/say-foo.cbot\");\n"
 " }"
+msgstr ""
+
+#. type: Plain text
+#: ../E/expr.txt:54
+#, no-wrap
+msgid ""
+"<code>+</code>  addition\n"
+"<code>-</code>  subtraction\n"
+"<code>*</code>  multiplication\n"
+"<code>/</code>  division\n"
+"<code>%</code>  remainder of the division (works for <code><a cbot|int>int</a></code> as well as <code><a cbot|float>float</a></code>)"
+msgstr ""
+
+#. type: Source code
+#: ../E/expr.txt:66
+#, no-wrap
+msgid ""
+" int    i = 12 + 3;      // i == 15\n"
+" int    i = 2 - 5;       // i == -3\n"
+" \n"
+" float  f = 3.01 * 10;   // f == 30.1\n"
+" \n"
+" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
+" float  f = 5 / 3;       // f == 1.67\n"
+" float  f = 5 / 0;       // returns an error (division by zero)\n"
+" \n"
+" int    i = 13 % 5;      // i == 3\n"
+" int    i = -8 % 3;      // i == -2\n"
+" float  f = -4.5 % 2.75; // f == -1.75\n"
+" \n"
+" float  f = sin(90) * i; // f == -2.0\n"
+" "
+msgstr ""
+
+#. type: Plain text
+#: ../E/expr.txt:91
+#, no-wrap
+msgid ""
+"<code>+=</code>  addition\n"
+"<code>-=</code>  subtraction\n"
+"<code>*=</code>  multiplication\n"
+"<code>/=</code>  division\n"
+"<code>%=</code>  remainder of the division"
+msgstr ""
+
+#. type: Plain text
+#: ../E/object.txt:4
+#, no-wrap
+msgid ""
+"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
+"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
+"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
+"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
+"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
+"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
+"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
+"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
+"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
+"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
+"<code>object object.energyCell   </code>Power cell on the bot\n"
+"<code>object object.load         </code>Object carried by the bot\n"
+"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
+"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object\n"
+"<code><a cbot|bool>bool</a>   object.dead         </code>Is the object dead?"
+msgstr ""
+
+#. type: Source code
+#: ../E/object.txt:67
+#, no-wrap
+msgid "<code>dead</code>"
+msgstr ""
+
+#. type: Plain text
+#: ../E/object.txt:68
+#, no-wrap
+msgid "True if the object was recently killed (while the death animation is playing). Note that accessing this property or any other property after the death animation finishes will cause an error that stops the program."
 msgstr ""

--- a/help/cbot/po/ru.po
+++ b/help/cbot/po/ru.po
@@ -53,13 +53,13 @@ msgid "Time in seconds."
 msgstr "Время в секундах."
 
 #. type: \t; header
-#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:197 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:79 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
+#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:198 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:83 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
 #, no-wrap
 msgid "See also"
 msgstr "См. также"
 
 #. type: Plain text
-#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:198 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:80 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
+#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:199 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:84 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
 #, no-wrap
 msgid "<a cbot>Programming</a>, <a cbot|type>types</a> and <a cbot|category>categories</a>."
 msgstr "<a cbot>Программирование</a>, <a cbot|type>типы</a> и <a cbot|category>категории</a>."
@@ -612,7 +612,7 @@ msgid "Conditions"
 msgstr "Условия"
 
 #. type: Plain text
-#: ../E/expr.txt:116
+#: ../E/expr.txt:117
 #, no-wrap
 msgid ""
 "<code>a == b  </code><code>a</code> equals <code>b</code>\n"
@@ -630,7 +630,7 @@ msgstr ""
 "<code>a >= b  </code><code>a</code> больше или равно <code>b</code>"
 
 #. type: Plain text
-#: ../E/expr.txt:124
+#: ../E/expr.txt:125
 #, no-wrap
 msgid ""
 "<code>12 == 12  </code>returns true\n"
@@ -648,13 +648,13 @@ msgstr ""
 "<code>12 >= 12  </code>возвращает да"
 
 #. type: Plain text
-#: ../E/expr.txt:132
+#: ../E/expr.txt:133
 #, no-wrap
 msgid "Be careful not to confuse the equality comparison <code>==</code> with the assignment of a <a cbot|var>variable</a> <code>=</code>."
 msgstr "Будьте внимательны и не путайте сравнение равенства <code>==</code> с присвоением <a cbot|var>переменной</a> <code>=</code>."
 
 #. type: Plain text
-#: ../E/expr.txt:134
+#: ../E/expr.txt:135
 #, no-wrap
 msgid ""
 "<code>a == b</code> is an expression that compares <code>a</code> with <code>b</code>.\n"
@@ -1260,29 +1260,13 @@ msgid "Expressions"
 msgstr "Выражения"
 
 #. type: Plain text
-#: ../E/expr.txt:86
+#: ../E/expr.txt:87
 #, no-wrap
 msgid "is equivalent to"
 msgstr " - это эквивалентено "
 
 #. type: Plain text
-#: ../E/expr.txt:90
-#, no-wrap
-msgid ""
-"<code>+=</code>  addition\n"
-"<code>-=</code>  subtraction\n"
-"<code>*=</code>  multiplication\n"
-"<code>/=</code>  division\n"
-"<code>%=</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
-msgstr ""
-"<code>+=</code>  сложение\n"
-"<code>-=</code>  вычитание\n"
-"<code>*=</code>  умножение\n"
-"<code>/=</code>  деление\n"
-"<code>%=</code>  остаток от деления (только для типа <code><a cbot|int>int</a></code>)"
-
-#. type: Plain text
-#: ../E/expr.txt:178
+#: ../E/expr.txt:179
 #, no-wrap
 msgid "The operators <code>++</code> and <code>--</code> allow you to increment (++) or to decrement (--) a variable in very compact and efficient manner."
 msgstr "Операторы <code>++</code> и <code>--</code> позволяют вам делать инкремент (++) или декремент (--) переменной очень компактным и эффективным образом."
@@ -2417,79 +2401,79 @@ msgid "Type <code>object</code>"
 msgstr "Тип <code>object</code>"
 
 #. type: Source code
-#: ../E/object.txt:21
+#: ../E/object.txt:22
 #, no-wrap
 msgid "<code>category</code>"
 msgstr "<code>category</code>"
 
 #. type: Source code
-#: ../E/object.txt:24
+#: ../E/object.txt:25
 #, no-wrap
 msgid "<code>position</code>"
 msgstr "<code>position</code>"
 
 #. type: Plain text
-#: ../E/object.txt:25
+#: ../E/object.txt:26
 #, no-wrap
 msgid "Position of the object on the planet, in meters. The coordinates <code>x</code> and <code>y</code> correspond to the location on a map, the <code>z</code> coordinate corresponds to the altitude above (respectively below) sea level. "
 msgstr "Положение объекта на планете в метрах. Координаты <code>x</code> и <code>y</code> соответствуют положению на карте, а координата <code>z</code> соответствует высоте над (и соответственно под) уровнем моря."
 
 #. type: Source code
-#: ../E/object.txt:27
+#: ../E/object.txt:28
 #, no-wrap
 msgid "<code>orientation</code>"
 msgstr "<code>orientation</code>"
 
 #. type: Plain text
-#: ../E/object.txt:28
+#: ../E/object.txt:29
 #, no-wrap
 msgid "Orientation of the object, in degrees. The orientation tells you what direction the object is facing. An orientation of <code>0</code> corresponds to an object facing eastwards, thus following the positive <code>x</code> axis. The orientation is measured counterclockwise. "
 msgstr "Ориентация объекта в градусах. Ориентация говорит вам о том, в каком направлении смотрит объект. Ориентация <code>0</code> соответствует объекту. который смотрит на восток, таким образом следуя положительному направлению оси <code>x</code>. Ориентация измеряется против часовой стрелки."
 
 #. type: Source code
-#: ../E/object.txt:30
+#: ../E/object.txt:31
 #, no-wrap
 msgid "<code>pitch</code>"
 msgstr "<code>pitch</code>"
 
 #. type: Plain text
-#: ../E/object.txt:31
+#: ../E/object.txt:32
 #, no-wrap
 msgid "Forward/backward angle of the robot. A pitch of <code>0</code> means that the bot is standing on flat ground. A positive inclination means that it is facing upwards, a negative inclination means that it is facing downwards. "
 msgstr "Передний/задний угол робота. Уклон равный <code>0</code> означает, что бот стоит на ровно поверхности. Положительный наклон означает, что он смотрит вверх, а отрицательный, что он смотрит вниз."
 
 #. type: Source code
-#: ../E/object.txt:33
+#: ../E/object.txt:34
 #, no-wrap
 msgid "<code>roll</code>"
 msgstr "<code>roll</code>"
 
 #. type: Plain text
-#: ../E/object.txt:34
+#: ../E/object.txt:35
 #, no-wrap
 msgid "Left/right angle of the bot, in degrees. A positive value means that the bot is leaning to the left side, a negative value means that it is leaning to the right side. "
 msgstr "Левый/правый угол бота в градусах. Положительное значение значит, что бот наклонен на левый бок, а отрицательное, что он клонится на правый бок."
 
 #. type: Source code
-#: ../E/object.txt:36
+#: ../E/object.txt:37
 #, no-wrap
 msgid "<code>energyLevel</code>"
 msgstr "<code>energyLevel</code>"
 
 #. type: Plain text
-#: ../E/object.txt:37
+#: ../E/object.txt:38
 #, no-wrap
 msgid "Energy level, between 0 and 1. A normal <a object|power>power cell</a> that is fully charged returns the value <code>1</code>. A <a object|atomic>nuclear power cell</a> never returns a value higher than 1, it just lasts longer. Attention: The energy level of a bot is always zero, because the energy is not contained in the bot, but in the power cell. To know the energy level of the power cell of a bot, you must write <code>energyCell.energyLevel</code>. "
 msgstr "Уровень энергии может быть от 0 до 1. Обычная <a object|power>энергетическая ячейка</a>, которая полностью заряжена, будет возвращать значение <code>1</code>. <a object|atomic>Ядерная энергетическая ячейка</a> тоже не будет возвращать значение больше 1, просто это значение будет держаться дольше. Внимание: энергетический уровень бота всегда равен нулю, так как энергия содержится не в боте, а в энергетической ячейке. Чтобы определить энергетический уровень энергетической ячейки бота, вы должны написать <code>energyCell.energyLevel</code>."
 
 #. type: Source code
-#: ../E/object.txt:39
+#: ../E/object.txt:40
 #, no-wrap
 msgid "<code>shieldLevel</code>"
 msgstr "<code>shieldLevel</code>"
 
 #. type: Plain text
-#: ../E/object.txt:40
+#: ../E/object.txt:41
 #, no-wrap
 msgid ""
 "Shield level of a robot or building. A level <code>1</code> indicates that the shield is still perfect. Every time that the bot or building gets a bullet or collides with another object, the shield level decreases. When the level reaches <code>0</code>, the next bullet or collision will destroy the bot or building. \n"
@@ -2499,49 +2483,49 @@ msgstr ""
 "Боты могут перезаряжать свои поля в <a object|repair>центре починки</a>. Поля здания восстанавливаются, если оно помещается внутрь защитной сферы <a object|botshld>полевика</a>."
 
 #. type: Source code
-#: ../E/object.txt:43
+#: ../E/object.txt:44
 #, no-wrap
 msgid "<code>temperature</code>"
 msgstr "<code>temperature</code>"
 
 #. type: Plain text
-#: ../E/object.txt:44
+#: ../E/object.txt:45
 #, no-wrap
 msgid "Temperature of the jet of <a object|botgj>winged bots</a>. <code>0</code> corresponds to a cold jet. When used, the temperature increases progressively. When it reaches the value <code>1</code>, the jet is overheated and stops working, until it cooled down a little. "
 msgstr "Температура нагрева реактивного двигателя <a object|botgj>летающих ботов</a>. <code>0</code> - соответствует холодному двигателю. В полёте температура прогрессивно увеличивается и когда она достигает значения <code>1</code>, двигатель перегревается и прекращает работу до тех пор, пока немного не остынет."
 
 #. type: Source code
-#: ../E/object.txt:46
+#: ../E/object.txt:47
 #, no-wrap
 msgid "<code>altitude</code>"
 msgstr "<code>altitude</code>"
 
 #. type: Plain text
-#: ../E/object.txt:47
+#: ../E/object.txt:48
 #, no-wrap
 msgid "The <code>z</code> coordinate of the position indicates the altitude above sea level, whereas the <code>altitude</code> indicates the height above ground. This value is meaningful only for <a object|botgj>winged bots</a> and for <a object|wasp>wasps</a>. For all other objects, this value is zero. "
 msgstr "Координата <code>z</code> показывает высоту над уровнем моря, в то время как <code>altitude</code> показывает высоту над уровнем земли. Это значение имеет смысл только для <a object|botgj>летающих ботов</a> и для <a object|wasp>ос</a>. Для всех остальных объектов оно равно нулю."
 
 #. type: Source code
-#: ../E/object.txt:49
+#: ../E/object.txt:50
 #, no-wrap
 msgid "<code>lifeTime</code>"
 msgstr "<code>lifeTime</code>"
 
 #. type: Plain text
-#: ../E/object.txt:50
+#: ../E/object.txt:51
 #, no-wrap
 msgid "The age of the object in seconds since it's creation."
 msgstr "Возраст объекта в секундах, с момента его создания."
 
 #. type: Source code
-#: ../E/object.txt:52
+#: ../E/object.txt:53
 #, no-wrap
 msgid "<code>energyCell</code>"
 msgstr "<code>energyCell</code>"
 
 #. type: Plain text
-#: ../E/object.txt:53
+#: ../E/object.txt:54
 #, no-wrap
 msgid ""
 "This information is special, because it returns the information about another object, in this case the power pack. This means that energyCell contains all the characteristics of a normal object, for example <code>category</code> (PowerCell or NuclearCell), <code>position</code> (the position of the cell), etc.\n"
@@ -2553,31 +2537,31 @@ msgstr ""
 "Если у бота нет энергетической ячейки, то <code>energyCell</code> вернет <code>null</code>."
 
 #. type: Source code
-#: ../E/object.txt:57
+#: ../E/object.txt:58
 #, no-wrap
 msgid "<code>load</code>"
 msgstr "<code>load</code>"
 
 #. type: Plain text
-#: ../E/object.txt:58
+#: ../E/object.txt:59
 #, no-wrap
 msgid "This information also returns the description of a whole object: the description of the object carried by a <a object|botgr>grabber</a>. If it carries nothing, <code>load</code> returns <code>null</code>."
 msgstr "Это значение также возвращает полное описание объекта, который переносит <a object|botgr>сборщик</a>. Если он ничего не несет, то <code>load</code> вернет <code>null</code>."
 
 #. type: \t; header, \b; header
-#: ../E/expr.txt:99 ../E/expr.txt:123 ../E/expr.txt:145 ../E/expr.txt:170 ../E/expr.txt:187 ../E/factory.txt:21 ../E/object.txt:66
+#: ../E/expr.txt:100 ../E/expr.txt:124 ../E/expr.txt:146 ../E/expr.txt:171 ../E/expr.txt:188 ../E/factory.txt:21 ../E/object.txt:70
 #, no-wrap
 msgid "Examples"
 msgstr "Примеры"
 
 #. type: Plain text
-#: ../E/object.txt:67
+#: ../E/object.txt:71
 #, no-wrap
 msgid "The type <code>object</code> returns the special value <code><a cbot|null>null</a></code> when the object does not exist. For example:"
 msgstr "Тип <code>object</code> возвращает особое значение <code><a cbot|null>null</a></code>, когда объект не существует. Например:"
 
 #. type: Source code
-#: ../E/object.txt:69
+#: ../E/object.txt:73
 #, no-wrap
 msgid ""
 "\tobject a;\n"
@@ -3207,7 +3191,7 @@ msgid "Returns the first object found that corresponds to the specified category
 msgstr "Возвращает первый найденный объект, который соответствует указанной категории в указанной зоне. Если объект найден не был, то возвращается значение <code><a cbot|null>null</a></code>."
 
 #. type: \t; header
-#: ../E/expr.txt:131 ../E/radar.txt:68
+#: ../E/expr.txt:132 ../E/radar.txt:68
 #, no-wrap
 msgid "Remark"
 msgstr "Замечание"
@@ -6360,71 +6344,37 @@ msgid "Use this type for variables that contain the characteristics of an object
 msgstr "Используйте этот тип переменный которые содержать характеристики объекта, будь то бот, здание, некоторое сырье, враг и т.п. Здесь приведены все свойства объекта:"
 
 #. type: Plain text
-#: ../E/object.txt:4
-#, no-wrap
-msgid ""
-"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
-"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
-"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
-"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
-"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
-"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
-"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
-"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
-"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
-"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
-"<code>object object.energyCell   </code>Power cell on the bot\n"
-"<code>object object.load         </code>Object carried by the bot\n"
-"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
-"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object"
-msgstr ""
-"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Категория</a> объекта\n"
-"<code><a cbot|point>point</a>  object.position     </code>Позиция объекта (x,y,z)\n"
-"<code><a cbot|float>float</a>  object.orientation  </code>Ориентация объекта (0..360) (Рысканье)\n"
-"<code><a cbot|float>float</a>  object.pitch        </code>Наклон (Тангаж) объекта вперед/назад\n"
-"<code><a cbot|float>float</a>  object.roll         </code>Наклон (Крен) объекта влево/вправо\n"
-"<code><a cbot|float>float</a>  object.energyLevel  </code>Заряд энергии (0..1)\n"
-"<code><a cbot|float>float</a>  object.shieldLevel  </code>Уровень брони (повреждений) (0..1)\n"
-"<code><a cbot|float>float</a>  object.temperature  </code>Температура реактивного двигателя (0..1)\n"
-"<code><a cbot|float>float</a>  object.altitude     </code>Высота над землей\n"
-"<code><a cbot|float>float</a>  object.lifeTime     </code>Время жизни объекта\n"
-"<code>object object.energyCell   </code>Элемент питания на борту бота\n"
-"<code>object object.load         </code>Объект транспортируемый ботом\n"
-"<code><a cbot|int>int</a>    object.team         </code>Команда объекта (см. <a battles>code battles</a>)\n"
-"<code><a cbot|point>point</a>  object.velocity     </code>Скорость объекта по трем осям"
-
-#. type: Plain text
-#: ../E/object.txt:19
+#: ../E/object.txt:20
 #, no-wrap
 msgid "Also, some objects have additional methods (instructions). See them in <a cbot>the main list</a> in the <c/>\"Instructions specific for some objects\" section."
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:22
+#: ../E/object.txt:23
 #, no-wrap
 msgid "The <n/><a cbot|category>category</a> of an object allows you to know what it is, f. ex. what kind of bot, building, enemy, etc."
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:60
+#: ../E/object.txt:61
 #, no-wrap
 msgid "<code>team</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:61
+#: ../E/object.txt:62
 #, no-wrap
 msgid "The bot's team. Used in <a battles>code battles</a>. If the object has no team assigned (e.g. in no team-based levels, the object being a resource), this is equal to <code>0</code>."
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:63
+#: ../E/object.txt:64
 #, no-wrap
 msgid "<code>velocity</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:64
+#: ../E/object.txt:65
 #, no-wrap
 msgid "Current velocity of the object. Should be treated as a three-dimensional vector."
 msgstr "Текущая скорость объекта. Должна рассматриваться как трехмерный вектор."
@@ -7341,21 +7291,10 @@ msgid "Binary operators below are working with fundamental number types (<code><
 msgstr ""
 
 #. type: \t; header
-#: ../E/expr.txt:53 ../E/expr.txt:89 ../E/expr.txt:115 ../E/expr.txt:140 ../E/expr.txt:163
+#: ../E/expr.txt:53 ../E/expr.txt:90 ../E/expr.txt:116 ../E/expr.txt:141 ../E/expr.txt:164
 #, no-wrap
 msgid "List"
 msgstr "Список"
-
-#. type: Plain text
-#: ../E/expr.txt:54
-#, no-wrap
-msgid ""
-"<code>+</code>  addition\n"
-"<code>-</code>  subtraction\n"
-"<code>*</code>  multiplication\n"
-"<code>/</code>  division\n"
-"<code>%</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
-msgstr ""
 
 #. type: \t; header
 #: ../E/expr.txt:60
@@ -7382,49 +7321,49 @@ msgid "Real life examples"
 msgstr "Примеры из реальной жизни"
 
 #. type: \t; header
-#: ../E/expr.txt:81
+#: ../E/expr.txt:82
 #, no-wrap
 msgid "Compound assignment operators"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:82
+#: ../E/expr.txt:83
 #, no-wrap
 msgid "Besides the <code>=</code> operator for variable assignment there are several compound-assignment operators."
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:84
+#: ../E/expr.txt:85
 #, no-wrap
 msgid "The compound-assignment operators combine the <code>=</code> assignment operator with another binary operator such as <code>+</code> or <code>-</code>. Compound-assignment operators perform the operation specified by the additional operator and then assign the result to the left operand. For example, a compound-assignment expression such as"
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:85
+#: ../E/expr.txt:86
 #, no-wrap
 msgid "<code>lvalue += expression</code>"
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:87
+#: ../E/expr.txt:88
 #, no-wrap
 msgid "<code>lvalue = lvalue + expression</code>"
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:96
+#: ../E/expr.txt:97
 #, no-wrap
 msgid "String concatenation"
 msgstr "Конкатенация (соединение) строк"
 
 #. type: Plain text
-#: ../E/expr.txt:97
+#: ../E/expr.txt:98
 #, no-wrap
 msgid "If at least one of the values used with the <code>+</code> operator is a <a cbot|string>string</a>, then the operation of concatenation is performed. The result of the operator is then a string, which is created by joining end-to-end the string and the other value. If the other value is not a string, then it is converted to string beforehand."
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:101
+#: ../E/expr.txt:102
 #, no-wrap
 msgid ""
 "\tstring s = \"a\" + \"bc\";  // returns \"abc\"\n"
@@ -7434,43 +7373,43 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:106
+#: ../E/expr.txt:107
 #, no-wrap
 msgid "Tip: the properties of the concatenation <code>+</code> operator is useful with the <a cbot|message>message();</a> function, because it does not work with other types than string. An empty string can be used together with a value in order to create a string, which actually can be passed to the <a cbot|message>message();</a> function:"
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:177
+#: ../E/expr.txt:178
 #, no-wrap
 msgid "Prefix and postfix increment- and decrement operators"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:180
+#: ../E/expr.txt:181
 #, no-wrap
 msgid "For example to increment the variable <code>a</code> you can write"
 msgstr "Например, чтобы инкрементировать переменную <code>a</code> вы можете написать"
 
 #. type: Source code
-#: ../E/expr.txt:181
+#: ../E/expr.txt:182
 #, no-wrap
 msgid "<c/>a++;<n/>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:182
+#: ../E/expr.txt:183
 #, no-wrap
 msgid "instead of"
 msgstr "вместо"
 
 #. type: Source code
-#: ../E/expr.txt:183
+#: ../E/expr.txt:184
 #, no-wrap
 msgid "<c/>a = a + 1;<n/>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:185
+#: ../E/expr.txt:186
 #, no-wrap
 msgid "The result of the operation <code>a++</code> is the value of the variable <code>a</code> *before* the increment. If you use the prefix operator <code>++a</code> the result of the operation is the value of the variable <code>a</code> *after* the increment. The same holds for the <code>--</code> decrement operator."
 msgstr ""
@@ -7494,27 +7433,7 @@ msgid "Note: it may be not obvious at first, but notice that <code>=</code> is a
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:66
-#, no-wrap
-msgid ""
-" int    i = 12 + 3;      // i == 15\n"
-" int    i = 2 - 5;       // i == -3\n"
-" \n"
-" float  f = 3.01 * 10;   // f == 30.1\n"
-" \n"
-" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
-" float  f = 5 / 3;       // f == 1.67\n"
-" float  f = 5 / 0;       // returns an error (division by zero)\n"
-" \n"
-" int    i = 13 % 5;      // i == 3\n"
-" int    i = -8 % 3;      // i == -2\n"
-" \n"
-" float  f = sin(90) * i; // f == -2.0\n"
-" "
-msgstr ""
-
-#. type: Source code
-#: ../E/expr.txt:108
+#: ../E/expr.txt:109
 #, no-wrap
 msgid ""
 " float pi = 3.14;\n"
@@ -7523,7 +7442,7 @@ msgid ""
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:189
+#: ../E/expr.txt:190
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -7532,7 +7451,7 @@ msgid ""
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:193
+#: ../E/expr.txt:194
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -7541,25 +7460,25 @@ msgid ""
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:137
+#: ../E/expr.txt:138
 #, no-wrap
 msgid "Logical operators"
 msgstr "Логические операторы"
 
 #. type: Plain text
-#: ../E/expr.txt:138
+#: ../E/expr.txt:139
 #, no-wrap
 msgid "Logical operators work with values of type <a cbot|bool>bool</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:150
+#: ../E/expr.txt:151
 #, no-wrap
 msgid "Ternary operator"
 msgstr "Тернарный оператор"
 
 #. type: Plain text
-#: ../E/expr.txt:151
+#: ../E/expr.txt:152
 #, no-wrap
 msgid ""
 "The ternary operator is nothing more than a syntax sugar. It is also known as \"inline if\". It might be confusing at first, because its syntax is a little more complicated than other operators. It can be described as follows:\n"
@@ -7568,19 +7487,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:155
+#: ../E/expr.txt:156
 #, no-wrap
 msgid "Firstly, the condition is valued and then the first result is returned if the condition is true, otherwise the second result is returned."
 msgstr ""
 
 #. type: \t; header
-#: ../E/expr.txt:157 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
+#: ../E/expr.txt:158 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
 #, no-wrap
 msgid "Example"
 msgstr "Пример"
 
 #. type: Source code
-#: ../E/expr.txt:158
+#: ../E/expr.txt:159
 #, no-wrap
 msgid "<c/>float c = ((3.0 > 2.0) ? 10.0 : -10.0); // c == 10.0<n/>"
 msgstr ""
@@ -7592,19 +7511,19 @@ msgid "A condition is a special <a cbot|expr>expression</a> that returns a <a cb
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:112
+#: ../E/expr.txt:113
 #, no-wrap
 msgid "Comparison operators"
 msgstr "Операторы сравнения"
 
 #. type: Plain text
-#: ../E/expr.txt:113
+#: ../E/expr.txt:114
 #, no-wrap
 msgid "Comparison operators work with values of type <a cbot|bool>float</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:141
+#: ../E/expr.txt:142
 #, no-wrap
 msgid ""
 "<code>!a      </code>not <code>a</code>\n"
@@ -7616,7 +7535,7 @@ msgstr ""
 "<code>a || b  </code><code>a</code> ИЛИ <code>b</code>"
 
 #. type: Plain text
-#: ../E/expr.txt:146
+#: ../E/expr.txt:147
 #, no-wrap
 msgid ""
 "<code>!false        </code>returns true\n"
@@ -7625,19 +7544,19 @@ msgid ""
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:160
+#: ../E/expr.txt:161
 #, no-wrap
 msgid "Bitwise operators"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:161
+#: ../E/expr.txt:162
 #, no-wrap
 msgid "Bitwise operators are similar to the logical operator, because they are operating on bits (which can be only 0 or 1, conditions can have a value only of false or true). So in theory, they should be working with basically any type of variable, because each value in the computer must be stored as a sequence of bits."
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:164
+#: ../E/expr.txt:165
 #, no-wrap
 msgid ""
 "<code>a & b  </code><code>a</code> AND <code>b</code>\n"
@@ -7648,7 +7567,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:171
+#: ../E/expr.txt:172
 #, no-wrap
 msgid ""
 "<code>2 & 1         </code>returns 0\n"
@@ -8999,4 +8918,80 @@ msgid ""
 " {\n"
 "     factory(WheeledGrabber, \"program/say-foo.cbot\");\n"
 " }"
+msgstr ""
+
+#. type: Plain text
+#: ../E/expr.txt:54
+#, no-wrap
+msgid ""
+"<code>+</code>  addition\n"
+"<code>-</code>  subtraction\n"
+"<code>*</code>  multiplication\n"
+"<code>/</code>  division\n"
+"<code>%</code>  remainder of the division (works for <code><a cbot|int>int</a></code> as well as <code><a cbot|float>float</a></code>)"
+msgstr ""
+
+#. type: Source code
+#: ../E/expr.txt:66
+#, no-wrap
+msgid ""
+" int    i = 12 + 3;      // i == 15\n"
+" int    i = 2 - 5;       // i == -3\n"
+" \n"
+" float  f = 3.01 * 10;   // f == 30.1\n"
+" \n"
+" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
+" float  f = 5 / 3;       // f == 1.67\n"
+" float  f = 5 / 0;       // returns an error (division by zero)\n"
+" \n"
+" int    i = 13 % 5;      // i == 3\n"
+" int    i = -8 % 3;      // i == -2\n"
+" float  f = -4.5 % 2.75; // f == -1.75\n"
+" \n"
+" float  f = sin(90) * i; // f == -2.0\n"
+" "
+msgstr ""
+
+#. type: Plain text
+#: ../E/expr.txt:91
+#, no-wrap
+msgid ""
+"<code>+=</code>  addition\n"
+"<code>-=</code>  subtraction\n"
+"<code>*=</code>  multiplication\n"
+"<code>/=</code>  division\n"
+"<code>%=</code>  remainder of the division"
+msgstr ""
+
+#. type: Plain text
+#: ../E/object.txt:4
+#, no-wrap
+msgid ""
+"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
+"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
+"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
+"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
+"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
+"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
+"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
+"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
+"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
+"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
+"<code>object object.energyCell   </code>Power cell on the bot\n"
+"<code>object object.load         </code>Object carried by the bot\n"
+"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
+"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object\n"
+"<code><a cbot|bool>bool</a>   object.dead         </code>Is the object dead?"
+msgstr ""
+
+#. type: Source code
+#: ../E/object.txt:67
+#, no-wrap
+msgid "<code>dead</code>"
+msgstr ""
+
+#. type: Plain text
+#: ../E/object.txt:68
+#, no-wrap
+msgid "True if the object was recently killed (while the death animation is playing). Note that accessing this property or any other property after the death animation finishes will cause an error that stops the program."
 msgstr ""

--- a/help/cbot/po/ru.po
+++ b/help/cbot/po/ru.po
@@ -53,13 +53,13 @@ msgid "Time in seconds."
 msgstr "Время в секундах."
 
 #. type: \t; header
-#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:198 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:83 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
+#: ../E/abstime.txt:10 ../E/acos.txt:11 ../E/aim.txt:23 ../E/array.txt:41 ../E/asin.txt:11 ../E/atan.txt:11 ../E/atan2.txt:16 ../E/bloc.txt:48 ../E/bool.txt:4 ../E/break.txt:24 ../E/build.txt:25 ../E/buildingenabled.txt:22 ../E/canbuild.txt:22 ../E/canresearch.txt:14 ../E/category.txt:119 ../E/ceil.txt:12 ../E/class.txt:120 ../E/close.txt:6 ../E/cond.txt:4 ../E/continue.txt:24 ../E/cos.txt:11 ../E/deflag.txt:12 ../E/deletef.txt:9 ../E/delinfo.txt:13 ../E/destroy.txt:15 ../E/detect.txt:27 ../E/direct.txt:13 ../E/dist.txt:29 ../E/dist2d.txt:13 ../E/do.txt:27 ../E/drop.txt:28 ../E/eof.txt:13 ../E/errmode.txt:32 ../E/expr.txt:197 ../E/extends.txt:105 ../E/extern.txt:29 ../E/factory.txt:61 ../E/false.txt:4 ../E/file.txt:16 ../E/fire.txt:30 ../E/flag.txt:19 ../E/flatgrnd.txt:16 ../E/flatspace.txt:25 ../E/float.txt:24 ../E/floor.txt:12 ../E/for.txt:51 ../E/function.txt:165 ../E/goto.txt:34 ../E/grab.txt:28 ../E/if.txt:39 ../E/int.txt:18 ../E/isbusy.txt:14 ../E/jet.txt:14 ../E/message.txt:24 ../E/motor.txt:38 ../E/move.txt:21 ../E/nan.txt:14 ../E/new.txt:20 ../E/null.txt:4 ../E/object.txt:79 ../E/open.txt:19 ../E/openfile.txt:11 ../E/pencolor.txt:14 ../E/pendown.txt:17 ../E/penup.txt:11 ../E/penwidth.txt:14 ../E/point.txt:35 ../E/pointer.txt:51 ../E/pow.txt:14 ../E/private.txt:19 ../E/produce.txt:30 ../E/protected.txt:26 ../E/public.txt:49 ../E/radar.txt:80 ../E/radarall.txt:19 ../E/rand.txt:8 ../E/readln.txt:18 ../E/receive.txt:16 ../E/recycle.txt:12 ../E/research.txt:18 ../E/researched.txt:14 ../E/researches.txt:29 ../E/retobj.txt:13 ../E/return.txt:29 ../E/round.txt:12 ../E/search.txt:25 ../E/send.txt:17 ../E/shield.txt:18 ../E/sin.txt:11 ../E/sizeof.txt:21 ../E/sniff.txt:16 ../E/space.txt:22 ../E/sqrt.txt:11 ../E/static.txt:20 ../E/strfind.txt:18 ../E/string.txt:32 ../E/strleft.txt:14 ../E/strlen.txt:12 ../E/strlower.txt:10 ../E/strmid.txt:18 ../E/strright.txt:14 ../E/strupper.txt:10 ../E/strval.txt:17 ../E/super.txt:45 ../E/switch.txt:70 ../E/synchro.txt:23 ../E/takeoff.txt:15 ../E/tan.txt:11 ../E/term.txt:30 ../E/testinfo.txt:16 ../E/this.txt:52 ../E/thump.txt:12 ../E/topo.txt:13 ../E/true.txt:4 ../E/trunc.txt:12 ../E/turn.txt:32 ../E/type.txt:32 ../E/var.txt:66 ../E/void.txt:10 ../E/wait.txt:21 ../E/while.txt:46 ../E/writeln.txt:19
 #, no-wrap
 msgid "See also"
 msgstr "См. также"
 
 #. type: Plain text
-#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:199 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:84 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
+#: ../E/abstime.txt:11 ../E/aim.txt:24 ../E/array.txt:42 ../E/bool.txt:5 ../E/break.txt:25 ../E/cond.txt:5 ../E/continue.txt:25 ../E/deflag.txt:13 ../E/deletef.txt:10 ../E/destroy.txt:16 ../E/detect.txt:28 ../E/direct.txt:14 ../E/dist.txt:30 ../E/dist2d.txt:14 ../E/drop.txt:29 ../E/errmode.txt:33 ../E/expr.txt:198 ../E/extern.txt:30 ../E/false.txt:5 ../E/fire.txt:31 ../E/flag.txt:20 ../E/flatgrnd.txt:17 ../E/flatspace.txt:26 ../E/float.txt:25 ../E/for.txt:52 ../E/function.txt:166 ../E/goto.txt:35 ../E/grab.txt:29 ../E/if.txt:40 ../E/int.txt:19 ../E/isbusy.txt:15 ../E/jet.txt:15 ../E/message.txt:25 ../E/move.txt:22 ../E/nan.txt:15 ../E/object.txt:80 ../E/openfile.txt:12 ../E/pencolor.txt:15 ../E/pendown.txt:18 ../E/penup.txt:12 ../E/penwidth.txt:15 ../E/point.txt:36 ../E/produce.txt:31 ../E/recycle.txt:13 ../E/retobj.txt:14 ../E/return.txt:30 ../E/search.txt:26 ../E/shield.txt:19 ../E/sizeof.txt:22 ../E/sniff.txt:17 ../E/space.txt:23 ../E/string.txt:33 ../E/switch.txt:71 ../E/takeoff.txt:16 ../E/term.txt:31 ../E/thump.txt:13 ../E/topo.txt:14 ../E/true.txt:5 ../E/turn.txt:33 ../E/type.txt:33 ../E/var.txt:67 ../E/void.txt:11 ../E/wait.txt:22
 #, no-wrap
 msgid "<a cbot>Programming</a>, <a cbot|type>types</a> and <a cbot|category>categories</a>."
 msgstr "<a cbot>Программирование</a>, <a cbot|type>типы</a> и <a cbot|category>категории</a>."
@@ -612,7 +612,7 @@ msgid "Conditions"
 msgstr "Условия"
 
 #. type: Plain text
-#: ../E/expr.txt:117
+#: ../E/expr.txt:116
 #, no-wrap
 msgid ""
 "<code>a == b  </code><code>a</code> equals <code>b</code>\n"
@@ -630,7 +630,7 @@ msgstr ""
 "<code>a >= b  </code><code>a</code> больше или равно <code>b</code>"
 
 #. type: Plain text
-#: ../E/expr.txt:125
+#: ../E/expr.txt:124
 #, no-wrap
 msgid ""
 "<code>12 == 12  </code>returns true\n"
@@ -648,13 +648,13 @@ msgstr ""
 "<code>12 >= 12  </code>возвращает да"
 
 #. type: Plain text
-#: ../E/expr.txt:133
+#: ../E/expr.txt:132
 #, no-wrap
 msgid "Be careful not to confuse the equality comparison <code>==</code> with the assignment of a <a cbot|var>variable</a> <code>=</code>."
 msgstr "Будьте внимательны и не путайте сравнение равенства <code>==</code> с присвоением <a cbot|var>переменной</a> <code>=</code>."
 
 #. type: Plain text
-#: ../E/expr.txt:135
+#: ../E/expr.txt:134
 #, no-wrap
 msgid ""
 "<code>a == b</code> is an expression that compares <code>a</code> with <code>b</code>.\n"
@@ -1260,13 +1260,29 @@ msgid "Expressions"
 msgstr "Выражения"
 
 #. type: Plain text
-#: ../E/expr.txt:87
+#: ../E/expr.txt:86
 #, no-wrap
 msgid "is equivalent to"
 msgstr " - это эквивалентено "
 
 #. type: Plain text
-#: ../E/expr.txt:179
+#: ../E/expr.txt:90
+#, no-wrap
+msgid ""
+"<code>+=</code>  addition\n"
+"<code>-=</code>  subtraction\n"
+"<code>*=</code>  multiplication\n"
+"<code>/=</code>  division\n"
+"<code>%=</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
+msgstr ""
+"<code>+=</code>  сложение\n"
+"<code>-=</code>  вычитание\n"
+"<code>*=</code>  умножение\n"
+"<code>/=</code>  деление\n"
+"<code>%=</code>  остаток от деления (только для типа <code><a cbot|int>int</a></code>)"
+
+#. type: Plain text
+#: ../E/expr.txt:178
 #, no-wrap
 msgid "The operators <code>++</code> and <code>--</code> allow you to increment (++) or to decrement (--) a variable in very compact and efficient manner."
 msgstr "Операторы <code>++</code> и <code>--</code> позволяют вам делать инкремент (++) или декремент (--) переменной очень компактным и эффективным образом."
@@ -2401,79 +2417,79 @@ msgid "Type <code>object</code>"
 msgstr "Тип <code>object</code>"
 
 #. type: Source code
-#: ../E/object.txt:22
+#: ../E/object.txt:21
 #, no-wrap
 msgid "<code>category</code>"
 msgstr "<code>category</code>"
 
 #. type: Source code
-#: ../E/object.txt:25
+#: ../E/object.txt:24
 #, no-wrap
 msgid "<code>position</code>"
 msgstr "<code>position</code>"
 
 #. type: Plain text
-#: ../E/object.txt:26
+#: ../E/object.txt:25
 #, no-wrap
 msgid "Position of the object on the planet, in meters. The coordinates <code>x</code> and <code>y</code> correspond to the location on a map, the <code>z</code> coordinate corresponds to the altitude above (respectively below) sea level. "
 msgstr "Положение объекта на планете в метрах. Координаты <code>x</code> и <code>y</code> соответствуют положению на карте, а координата <code>z</code> соответствует высоте над (и соответственно под) уровнем моря."
 
 #. type: Source code
-#: ../E/object.txt:28
+#: ../E/object.txt:27
 #, no-wrap
 msgid "<code>orientation</code>"
 msgstr "<code>orientation</code>"
 
 #. type: Plain text
-#: ../E/object.txt:29
+#: ../E/object.txt:28
 #, no-wrap
 msgid "Orientation of the object, in degrees. The orientation tells you what direction the object is facing. An orientation of <code>0</code> corresponds to an object facing eastwards, thus following the positive <code>x</code> axis. The orientation is measured counterclockwise. "
 msgstr "Ориентация объекта в градусах. Ориентация говорит вам о том, в каком направлении смотрит объект. Ориентация <code>0</code> соответствует объекту. который смотрит на восток, таким образом следуя положительному направлению оси <code>x</code>. Ориентация измеряется против часовой стрелки."
 
 #. type: Source code
-#: ../E/object.txt:31
+#: ../E/object.txt:30
 #, no-wrap
 msgid "<code>pitch</code>"
 msgstr "<code>pitch</code>"
 
 #. type: Plain text
-#: ../E/object.txt:32
+#: ../E/object.txt:31
 #, no-wrap
 msgid "Forward/backward angle of the robot. A pitch of <code>0</code> means that the bot is standing on flat ground. A positive inclination means that it is facing upwards, a negative inclination means that it is facing downwards. "
 msgstr "Передний/задний угол робота. Уклон равный <code>0</code> означает, что бот стоит на ровно поверхности. Положительный наклон означает, что он смотрит вверх, а отрицательный, что он смотрит вниз."
 
 #. type: Source code
-#: ../E/object.txt:34
+#: ../E/object.txt:33
 #, no-wrap
 msgid "<code>roll</code>"
 msgstr "<code>roll</code>"
 
 #. type: Plain text
-#: ../E/object.txt:35
+#: ../E/object.txt:34
 #, no-wrap
 msgid "Left/right angle of the bot, in degrees. A positive value means that the bot is leaning to the left side, a negative value means that it is leaning to the right side. "
 msgstr "Левый/правый угол бота в градусах. Положительное значение значит, что бот наклонен на левый бок, а отрицательное, что он клонится на правый бок."
 
 #. type: Source code
-#: ../E/object.txt:37
+#: ../E/object.txt:36
 #, no-wrap
 msgid "<code>energyLevel</code>"
 msgstr "<code>energyLevel</code>"
 
 #. type: Plain text
-#: ../E/object.txt:38
+#: ../E/object.txt:37
 #, no-wrap
 msgid "Energy level, between 0 and 1. A normal <a object|power>power cell</a> that is fully charged returns the value <code>1</code>. A <a object|atomic>nuclear power cell</a> never returns a value higher than 1, it just lasts longer. Attention: The energy level of a bot is always zero, because the energy is not contained in the bot, but in the power cell. To know the energy level of the power cell of a bot, you must write <code>energyCell.energyLevel</code>. "
 msgstr "Уровень энергии может быть от 0 до 1. Обычная <a object|power>энергетическая ячейка</a>, которая полностью заряжена, будет возвращать значение <code>1</code>. <a object|atomic>Ядерная энергетическая ячейка</a> тоже не будет возвращать значение больше 1, просто это значение будет держаться дольше. Внимание: энергетический уровень бота всегда равен нулю, так как энергия содержится не в боте, а в энергетической ячейке. Чтобы определить энергетический уровень энергетической ячейки бота, вы должны написать <code>energyCell.energyLevel</code>."
 
 #. type: Source code
-#: ../E/object.txt:40
+#: ../E/object.txt:39
 #, no-wrap
 msgid "<code>shieldLevel</code>"
 msgstr "<code>shieldLevel</code>"
 
 #. type: Plain text
-#: ../E/object.txt:41
+#: ../E/object.txt:40
 #, no-wrap
 msgid ""
 "Shield level of a robot or building. A level <code>1</code> indicates that the shield is still perfect. Every time that the bot or building gets a bullet or collides with another object, the shield level decreases. When the level reaches <code>0</code>, the next bullet or collision will destroy the bot or building. \n"
@@ -2483,49 +2499,49 @@ msgstr ""
 "Боты могут перезаряжать свои поля в <a object|repair>центре починки</a>. Поля здания восстанавливаются, если оно помещается внутрь защитной сферы <a object|botshld>полевика</a>."
 
 #. type: Source code
-#: ../E/object.txt:44
+#: ../E/object.txt:43
 #, no-wrap
 msgid "<code>temperature</code>"
 msgstr "<code>temperature</code>"
 
 #. type: Plain text
-#: ../E/object.txt:45
+#: ../E/object.txt:44
 #, no-wrap
 msgid "Temperature of the jet of <a object|botgj>winged bots</a>. <code>0</code> corresponds to a cold jet. When used, the temperature increases progressively. When it reaches the value <code>1</code>, the jet is overheated and stops working, until it cooled down a little. "
 msgstr "Температура нагрева реактивного двигателя <a object|botgj>летающих ботов</a>. <code>0</code> - соответствует холодному двигателю. В полёте температура прогрессивно увеличивается и когда она достигает значения <code>1</code>, двигатель перегревается и прекращает работу до тех пор, пока немного не остынет."
 
 #. type: Source code
-#: ../E/object.txt:47
+#: ../E/object.txt:46
 #, no-wrap
 msgid "<code>altitude</code>"
 msgstr "<code>altitude</code>"
 
 #. type: Plain text
-#: ../E/object.txt:48
+#: ../E/object.txt:47
 #, no-wrap
 msgid "The <code>z</code> coordinate of the position indicates the altitude above sea level, whereas the <code>altitude</code> indicates the height above ground. This value is meaningful only for <a object|botgj>winged bots</a> and for <a object|wasp>wasps</a>. For all other objects, this value is zero. "
 msgstr "Координата <code>z</code> показывает высоту над уровнем моря, в то время как <code>altitude</code> показывает высоту над уровнем земли. Это значение имеет смысл только для <a object|botgj>летающих ботов</a> и для <a object|wasp>ос</a>. Для всех остальных объектов оно равно нулю."
 
 #. type: Source code
-#: ../E/object.txt:50
+#: ../E/object.txt:49
 #, no-wrap
 msgid "<code>lifeTime</code>"
 msgstr "<code>lifeTime</code>"
 
 #. type: Plain text
-#: ../E/object.txt:51
+#: ../E/object.txt:50
 #, no-wrap
 msgid "The age of the object in seconds since it's creation."
 msgstr "Возраст объекта в секундах, с момента его создания."
 
 #. type: Source code
-#: ../E/object.txt:53
+#: ../E/object.txt:52
 #, no-wrap
 msgid "<code>energyCell</code>"
 msgstr "<code>energyCell</code>"
 
 #. type: Plain text
-#: ../E/object.txt:54
+#: ../E/object.txt:53
 #, no-wrap
 msgid ""
 "This information is special, because it returns the information about another object, in this case the power pack. This means that energyCell contains all the characteristics of a normal object, for example <code>category</code> (PowerCell or NuclearCell), <code>position</code> (the position of the cell), etc.\n"
@@ -2537,31 +2553,31 @@ msgstr ""
 "Если у бота нет энергетической ячейки, то <code>energyCell</code> вернет <code>null</code>."
 
 #. type: Source code
-#: ../E/object.txt:58
+#: ../E/object.txt:57
 #, no-wrap
 msgid "<code>load</code>"
 msgstr "<code>load</code>"
 
 #. type: Plain text
-#: ../E/object.txt:59
+#: ../E/object.txt:58
 #, no-wrap
 msgid "This information also returns the description of a whole object: the description of the object carried by a <a object|botgr>grabber</a>. If it carries nothing, <code>load</code> returns <code>null</code>."
 msgstr "Это значение также возвращает полное описание объекта, который переносит <a object|botgr>сборщик</a>. Если он ничего не несет, то <code>load</code> вернет <code>null</code>."
 
 #. type: \t; header, \b; header
-#: ../E/expr.txt:100 ../E/expr.txt:124 ../E/expr.txt:146 ../E/expr.txt:171 ../E/expr.txt:188 ../E/factory.txt:21 ../E/object.txt:70
+#: ../E/expr.txt:99 ../E/expr.txt:123 ../E/expr.txt:145 ../E/expr.txt:170 ../E/expr.txt:187 ../E/factory.txt:21 ../E/object.txt:66
 #, no-wrap
 msgid "Examples"
 msgstr "Примеры"
 
 #. type: Plain text
-#: ../E/object.txt:71
+#: ../E/object.txt:67
 #, no-wrap
 msgid "The type <code>object</code> returns the special value <code><a cbot|null>null</a></code> when the object does not exist. For example:"
 msgstr "Тип <code>object</code> возвращает особое значение <code><a cbot|null>null</a></code>, когда объект не существует. Например:"
 
 #. type: Source code
-#: ../E/object.txt:73
+#: ../E/object.txt:69
 #, no-wrap
 msgid ""
 "\tobject a;\n"
@@ -3191,7 +3207,7 @@ msgid "Returns the first object found that corresponds to the specified category
 msgstr "Возвращает первый найденный объект, который соответствует указанной категории в указанной зоне. Если объект найден не был, то возвращается значение <code><a cbot|null>null</a></code>."
 
 #. type: \t; header
-#: ../E/expr.txt:132 ../E/radar.txt:68
+#: ../E/expr.txt:131 ../E/radar.txt:68
 #, no-wrap
 msgid "Remark"
 msgstr "Замечание"
@@ -6344,37 +6360,71 @@ msgid "Use this type for variables that contain the characteristics of an object
 msgstr "Используйте этот тип переменный которые содержать характеристики объекта, будь то бот, здание, некоторое сырье, враг и т.п. Здесь приведены все свойства объекта:"
 
 #. type: Plain text
-#: ../E/object.txt:20
+#: ../E/object.txt:4
+#, no-wrap
+msgid ""
+"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
+"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
+"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
+"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
+"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
+"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
+"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
+"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
+"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
+"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
+"<code>object object.energyCell   </code>Power cell on the bot\n"
+"<code>object object.load         </code>Object carried by the bot\n"
+"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
+"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object"
+msgstr ""
+"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Категория</a> объекта\n"
+"<code><a cbot|point>point</a>  object.position     </code>Позиция объекта (x,y,z)\n"
+"<code><a cbot|float>float</a>  object.orientation  </code>Ориентация объекта (0..360) (Рысканье)\n"
+"<code><a cbot|float>float</a>  object.pitch        </code>Наклон (Тангаж) объекта вперед/назад\n"
+"<code><a cbot|float>float</a>  object.roll         </code>Наклон (Крен) объекта влево/вправо\n"
+"<code><a cbot|float>float</a>  object.energyLevel  </code>Заряд энергии (0..1)\n"
+"<code><a cbot|float>float</a>  object.shieldLevel  </code>Уровень брони (повреждений) (0..1)\n"
+"<code><a cbot|float>float</a>  object.temperature  </code>Температура реактивного двигателя (0..1)\n"
+"<code><a cbot|float>float</a>  object.altitude     </code>Высота над землей\n"
+"<code><a cbot|float>float</a>  object.lifeTime     </code>Время жизни объекта\n"
+"<code>object object.energyCell   </code>Элемент питания на борту бота\n"
+"<code>object object.load         </code>Объект транспортируемый ботом\n"
+"<code><a cbot|int>int</a>    object.team         </code>Команда объекта (см. <a battles>code battles</a>)\n"
+"<code><a cbot|point>point</a>  object.velocity     </code>Скорость объекта по трем осям"
+
+#. type: Plain text
+#: ../E/object.txt:19
 #, no-wrap
 msgid "Also, some objects have additional methods (instructions). See them in <a cbot>the main list</a> in the <c/>\"Instructions specific for some objects\" section."
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:23
+#: ../E/object.txt:22
 #, no-wrap
 msgid "The <n/><a cbot|category>category</a> of an object allows you to know what it is, f. ex. what kind of bot, building, enemy, etc."
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:61
+#: ../E/object.txt:60
 #, no-wrap
 msgid "<code>team</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:62
+#: ../E/object.txt:61
 #, no-wrap
 msgid "The bot's team. Used in <a battles>code battles</a>. If the object has no team assigned (e.g. in no team-based levels, the object being a resource), this is equal to <code>0</code>."
 msgstr ""
 
 #. type: Source code
-#: ../E/object.txt:64
+#: ../E/object.txt:63
 #, no-wrap
 msgid "<code>velocity</code>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/object.txt:65
+#: ../E/object.txt:64
 #, no-wrap
 msgid "Current velocity of the object. Should be treated as a three-dimensional vector."
 msgstr "Текущая скорость объекта. Должна рассматриваться как трехмерный вектор."
@@ -7291,10 +7341,21 @@ msgid "Binary operators below are working with fundamental number types (<code><
 msgstr ""
 
 #. type: \t; header
-#: ../E/expr.txt:53 ../E/expr.txt:90 ../E/expr.txt:116 ../E/expr.txt:141 ../E/expr.txt:164
+#: ../E/expr.txt:53 ../E/expr.txt:89 ../E/expr.txt:115 ../E/expr.txt:140 ../E/expr.txt:163
 #, no-wrap
 msgid "List"
 msgstr "Список"
+
+#. type: Plain text
+#: ../E/expr.txt:54
+#, no-wrap
+msgid ""
+"<code>+</code>  addition\n"
+"<code>-</code>  subtraction\n"
+"<code>*</code>  multiplication\n"
+"<code>/</code>  division\n"
+"<code>%</code>  remainder of the division (only for the type <code><a cbot|int>int</a></code>)"
+msgstr ""
 
 #. type: \t; header
 #: ../E/expr.txt:60
@@ -7321,49 +7382,49 @@ msgid "Real life examples"
 msgstr "Примеры из реальной жизни"
 
 #. type: \t; header
-#: ../E/expr.txt:82
+#: ../E/expr.txt:81
 #, no-wrap
 msgid "Compound assignment operators"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:83
+#: ../E/expr.txt:82
 #, no-wrap
 msgid "Besides the <code>=</code> operator for variable assignment there are several compound-assignment operators."
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:85
+#: ../E/expr.txt:84
 #, no-wrap
 msgid "The compound-assignment operators combine the <code>=</code> assignment operator with another binary operator such as <code>+</code> or <code>-</code>. Compound-assignment operators perform the operation specified by the additional operator and then assign the result to the left operand. For example, a compound-assignment expression such as"
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:86
+#: ../E/expr.txt:85
 #, no-wrap
 msgid "<code>lvalue += expression</code>"
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:88
+#: ../E/expr.txt:87
 #, no-wrap
 msgid "<code>lvalue = lvalue + expression</code>"
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:97
+#: ../E/expr.txt:96
 #, no-wrap
 msgid "String concatenation"
 msgstr "Конкатенация (соединение) строк"
 
 #. type: Plain text
-#: ../E/expr.txt:98
+#: ../E/expr.txt:97
 #, no-wrap
 msgid "If at least one of the values used with the <code>+</code> operator is a <a cbot|string>string</a>, then the operation of concatenation is performed. The result of the operator is then a string, which is created by joining end-to-end the string and the other value. If the other value is not a string, then it is converted to string beforehand."
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:102
+#: ../E/expr.txt:101
 #, no-wrap
 msgid ""
 "\tstring s = \"a\" + \"bc\";  // returns \"abc\"\n"
@@ -7373,43 +7434,43 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:107
+#: ../E/expr.txt:106
 #, no-wrap
 msgid "Tip: the properties of the concatenation <code>+</code> operator is useful with the <a cbot|message>message();</a> function, because it does not work with other types than string. An empty string can be used together with a value in order to create a string, which actually can be passed to the <a cbot|message>message();</a> function:"
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:178
+#: ../E/expr.txt:177
 #, no-wrap
 msgid "Prefix and postfix increment- and decrement operators"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:181
+#: ../E/expr.txt:180
 #, no-wrap
 msgid "For example to increment the variable <code>a</code> you can write"
 msgstr "Например, чтобы инкрементировать переменную <code>a</code> вы можете написать"
 
 #. type: Source code
-#: ../E/expr.txt:182
+#: ../E/expr.txt:181
 #, no-wrap
 msgid "<c/>a++;<n/>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:183
+#: ../E/expr.txt:182
 #, no-wrap
 msgid "instead of"
 msgstr "вместо"
 
 #. type: Source code
-#: ../E/expr.txt:184
+#: ../E/expr.txt:183
 #, no-wrap
 msgid "<c/>a = a + 1;<n/>"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:186
+#: ../E/expr.txt:185
 #, no-wrap
 msgid "The result of the operation <code>a++</code> is the value of the variable <code>a</code> *before* the increment. If you use the prefix operator <code>++a</code> the result of the operation is the value of the variable <code>a</code> *after* the increment. The same holds for the <code>--</code> decrement operator."
 msgstr ""
@@ -7433,7 +7494,27 @@ msgid "Note: it may be not obvious at first, but notice that <code>=</code> is a
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:109
+#: ../E/expr.txt:66
+#, no-wrap
+msgid ""
+" int    i = 12 + 3;      // i == 15\n"
+" int    i = 2 - 5;       // i == -3\n"
+" \n"
+" float  f = 3.01 * 10;   // f == 30.1\n"
+" \n"
+" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
+" float  f = 5 / 3;       // f == 1.67\n"
+" float  f = 5 / 0;       // returns an error (division by zero)\n"
+" \n"
+" int    i = 13 % 5;      // i == 3\n"
+" int    i = -8 % 3;      // i == -2\n"
+" \n"
+" float  f = sin(90) * i; // f == -2.0\n"
+" "
+msgstr ""
+
+#. type: Source code
+#: ../E/expr.txt:108
 #, no-wrap
 msgid ""
 " float pi = 3.14;\n"
@@ -7442,7 +7523,7 @@ msgid ""
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:190
+#: ../E/expr.txt:189
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -7451,7 +7532,7 @@ msgid ""
 msgstr ""
 
 #. type: Source code
-#: ../E/expr.txt:194
+#: ../E/expr.txt:193
 #, no-wrap
 msgid ""
 " a = 2;\n"
@@ -7460,25 +7541,25 @@ msgid ""
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:138
+#: ../E/expr.txt:137
 #, no-wrap
 msgid "Logical operators"
 msgstr "Логические операторы"
 
 #. type: Plain text
-#: ../E/expr.txt:139
+#: ../E/expr.txt:138
 #, no-wrap
 msgid "Logical operators work with values of type <a cbot|bool>bool</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:151
+#: ../E/expr.txt:150
 #, no-wrap
 msgid "Ternary operator"
 msgstr "Тернарный оператор"
 
 #. type: Plain text
-#: ../E/expr.txt:152
+#: ../E/expr.txt:151
 #, no-wrap
 msgid ""
 "The ternary operator is nothing more than a syntax sugar. It is also known as \"inline if\". It might be confusing at first, because its syntax is a little more complicated than other operators. It can be described as follows:\n"
@@ -7487,19 +7568,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:156
+#: ../E/expr.txt:155
 #, no-wrap
 msgid "Firstly, the condition is valued and then the first result is returned if the condition is true, otherwise the second result is returned."
 msgstr ""
 
 #. type: \t; header
-#: ../E/expr.txt:158 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
+#: ../E/expr.txt:157 ../E/extends.txt:4 ../E/extends.txt:65 ../E/private.txt:4 ../E/protected.txt:4 ../E/super.txt:4
 #, no-wrap
 msgid "Example"
 msgstr "Пример"
 
 #. type: Source code
-#: ../E/expr.txt:159
+#: ../E/expr.txt:158
 #, no-wrap
 msgid "<c/>float c = ((3.0 > 2.0) ? 10.0 : -10.0); // c == 10.0<n/>"
 msgstr ""
@@ -7511,19 +7592,19 @@ msgid "A condition is a special <a cbot|expr>expression</a> that returns a <a cb
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:113
+#: ../E/expr.txt:112
 #, no-wrap
 msgid "Comparison operators"
 msgstr "Операторы сравнения"
 
 #. type: Plain text
-#: ../E/expr.txt:114
+#: ../E/expr.txt:113
 #, no-wrap
 msgid "Comparison operators work with values of type <a cbot|bool>float</a> and they always return a <a cbot|bool>bool</a>. They are mainly used in <a cbot|cond>conditions</a>."
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:142
+#: ../E/expr.txt:141
 #, no-wrap
 msgid ""
 "<code>!a      </code>not <code>a</code>\n"
@@ -7535,7 +7616,7 @@ msgstr ""
 "<code>a || b  </code><code>a</code> ИЛИ <code>b</code>"
 
 #. type: Plain text
-#: ../E/expr.txt:147
+#: ../E/expr.txt:146
 #, no-wrap
 msgid ""
 "<code>!false        </code>returns true\n"
@@ -7544,19 +7625,19 @@ msgid ""
 msgstr ""
 
 #. type: \b; header
-#: ../E/expr.txt:161
+#: ../E/expr.txt:160
 #, no-wrap
 msgid "Bitwise operators"
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:162
+#: ../E/expr.txt:161
 #, no-wrap
 msgid "Bitwise operators are similar to the logical operator, because they are operating on bits (which can be only 0 or 1, conditions can have a value only of false or true). So in theory, they should be working with basically any type of variable, because each value in the computer must be stored as a sequence of bits."
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:165
+#: ../E/expr.txt:164
 #, no-wrap
 msgid ""
 "<code>a & b  </code><code>a</code> AND <code>b</code>\n"
@@ -7567,7 +7648,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: ../E/expr.txt:172
+#: ../E/expr.txt:171
 #, no-wrap
 msgid ""
 "<code>2 & 1         </code>returns 0\n"
@@ -8919,104 +9000,3 @@ msgid ""
 "     factory(WheeledGrabber, \"program/say-foo.cbot\");\n"
 " }"
 msgstr ""
-
-#. type: Plain text
-#: ../E/expr.txt:54
-#, no-wrap
-msgid ""
-"<code>+</code>  addition\n"
-"<code>-</code>  subtraction\n"
-"<code>*</code>  multiplication\n"
-"<code>/</code>  division\n"
-"<code>%</code>  remainder of the division (works for <code><a cbot|int>int</a></code> as well as <code><a cbot|float>float</a></code>)"
-msgstr ""
-"<code>+=</code>  сложение\n"
-"<code>-=</code>  вычитание\n"
-"<code>*=</code>  умножение\n"
-"<code>/=</code>  деление\n"
-"<code>%=</code>  остаток от деления (работает для <code><a cbot|int>int</a></code>, а также для <code><a cbot|float>float</a></code>)"
-
-#. type: Source code
-#: ../E/expr.txt:66
-#, no-wrap
-msgid ""
-" int    i = 12 + 3;      // i == 15\n"
-" int    i = 2 - 5;       // i == -3\n"
-" \n"
-" float  f = 3.01 * 10;   // f == 30.1\n"
-" \n"
-" int    i = 5 / 3;       // i == 1 (automatic conversion to int)\n"
-" float  f = 5 / 3;       // f == 1.67\n"
-" float  f = 5 / 0;       // returns an error (division by zero)\n"
-" \n"
-" int    i = 13 % 5;      // i == 3\n"
-" int    i = -8 % 3;      // i == -2\n"
-" float  f = -4.5 % 2.75; // f == -1.75\n"
-" \n"
-" float  f = sin(90) * i; // f == -2.0\n"
-" "
-msgstr ""
-
-#. type: Plain text
-#: ../E/expr.txt:91
-#, no-wrap
-msgid ""
-"<code>+=</code>  addition\n"
-"<code>-=</code>  subtraction\n"
-"<code>*=</code>  multiplication\n"
-"<code>/=</code>  division\n"
-"<code>%=</code>  remainder of the division"
-msgstr ""
-"<code>+=</code>  сложение\n"
-"<code>-=</code>  вычитание\n"
-"<code>*=</code>  умножение\n"
-"<code>/=</code>  деление\n"
-"<code>%=</code>  остаток от деления"
-
-#. type: Plain text
-#: ../E/object.txt:4
-#, no-wrap
-msgid ""
-"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Category</a> of the object\n"
-"<code><a cbot|point>point</a>  object.position     </code>Position of the object (x,y,z)\n"
-"<code><a cbot|float>float</a>  object.orientation  </code>Orientation of the object (0..360)\n"
-"<code><a cbot|float>float</a>  object.pitch        </code>Forward/backward angle of the object\n"
-"<code><a cbot|float>float</a>  object.roll         </code>Right/left angle of the object \n"
-"<code><a cbot|float>float</a>  object.energyLevel  </code>Energy level (0..1)\n"
-"<code><a cbot|float>float</a>  object.shieldLevel  </code>Shield level (0..1)\n"
-"<code><a cbot|float>float</a>  object.temperature  </code>Jet temperature (0..1)\n"
-"<code><a cbot|float>float</a>  object.altitude     </code>Altitude above ground\n"
-"<code><a cbot|float>float</a>  object.lifeTime     </code>Lifetime of the object\n"
-"<code>object object.energyCell   </code>Power cell on the bot\n"
-"<code>object object.load         </code>Object carried by the bot\n"
-"<code><a cbot|int>int</a>    object.team         </code>The object's team (see <a battles>code battles</a>)\n"
-"<code><a cbot|point>point</a>  object.velocity     </code>Velocity of the object\n"
-"<code><a cbot|bool>bool</a>   object.dead         </code>Is the object dead?"
-msgstr ""
-"<code><a cbot|int>int</a>    object.category     </code><a cbot|category>Категория</a> объекта\n"
-"<code><a cbot|point>point</a>  object.position     </code>Позиция объекта (x,y,z)\n"
-"<code><a cbot|float>float</a>  object.orientation  </code>Ориентация объекта (0..360) (Рысканье)\n"
-"<code><a cbot|float>float</a>  object.pitch        </code>Наклон (Тангаж) объекта вперед/назад\n"
-"<code><a cbot|float>float</a>  object.roll         </code>Наклон (Крен) объекта влево/вправо\n"
-"<code><a cbot|float>float</a>  object.energyLevel  </code>Заряд энергии (0..1)\n"
-"<code><a cbot|float>float</a>  object.shieldLevel  </code>Уровень брони (повреждений) (0..1)\n"
-"<code><a cbot|float>float</a>  object.temperature  </code>Температура реактивного двигателя (0..1)\n"
-"<code><a cbot|float>float</a>  object.altitude     </code>Высота над землей\n"
-"<code><a cbot|float>float</a>  object.lifeTime     </code>Время жизни объекта\n"
-"<code>object object.energyCell   </code>Элемент питания на борту бота\n"
-"<code>object object.load         </code>Объект транспортируемый ботом\n"
-"<code><a cbot|int>int</a>    object.team         </code>Команда объекта (см. <a battles>code battles</a>)\n"
-"<code><a cbot|point>point</a>  object.velocity     </code>Скорость объекта по трем осям\n"
-"<code><a cbot|bool>bool</a>   object.dead         </code>Мертв ли объект?"
-
-#. type: Source code
-#: ../E/object.txt:67
-#, no-wrap
-msgid "<code>dead</code>"
-msgstr ""
-
-#. type: Plain text
-#: ../E/object.txt:68
-#, no-wrap
-msgid "True if the object was recently killed (while the death animation is playing). Note that accessing this property or any other property after the death animation finishes will cause an error that stops the program."
-msgstr "True, если объект был недавно убит (во время воспроизведения анимации смерти). Обратите внимание, что доступ к этому свойству или любому другому свойству после завершения анимации смерти вызовет ошибку, которая остановит программу."


### PR DESCRIPTION
Add Czech translation of new texts in `factory()` and expression help files.

This PR partially reverts #89 and #116 to remove machine translations from help files so that human translators can actually see the new texts and translate them properly.