### PR TITLE
Update upload-artifact to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       working-directory: build
       run: DESTDIR=. make install
     - name: Upload build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: data
         path: build/install


### PR DESCRIPTION
upload-artifact-v3 action is deprecated since long time. While main repo got updated version, data still got left with non-functioning version.
This PR fixes that.